### PR TITLE
Provide aggregate durations on front page

### DIFF
--- a/src/main/java/hudson/plugins/testng/results/PackageResult.java
+++ b/src/main/java/hudson/plugins/testng/results/PackageResult.java
@@ -95,12 +95,12 @@ public class PackageResult extends BaseResult implements ModelObject {
       skip = 0;
       total = 0;
       for (ClassResult _c : classList) {
+          _c.setParent(this);
+          _c.tally();
          duration += _c.getDuration();
          fail += _c.getFail();
          skip += _c.getSkip();
          total += _c.getTotal();
-         _c.setParent(this);
-         _c.tally();
       }
    }
 

--- a/src/test/java/hudson.plugins.testng.parser/TestParser.java
+++ b/src/test/java/hudson.plugins.testng.parser/TestParser.java
@@ -3,6 +3,7 @@ package hudson.plugins.testng.parser;
 import org.junit.Test;
 
 import hudson.plugins.testng.results.TestResults;
+import hudson.plugins.testng.results.PackageResult;
 
 import java.io.File;
 import java.net.URL;
@@ -10,6 +11,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
 
 import junit.framework.Assert;
 
@@ -23,12 +25,31 @@ public class TestParser {
       Collection<TestResults> results = ResultsParser.parse(new File(resource.getFile()), null);
       Assert.assertFalse("Collection shouldn't have been empty", results.isEmpty());
    }
-   
+
+   @Test
+   public void testTestngXmlWithExistingResultXmlGetsTheRightDurations() {
+      String filename = "sample-testng-dp-result.xml";
+      URL resource = TestParser.class.getClassLoader().getResource(filename);
+      Assert.assertNotNull(resource);
+      Collection<TestResults> results = ResultsParser.parse(new File(resource.getFile()), null);
+      Assert.assertFalse("Collection shouldn't have been empty", results.isEmpty());
+
+      // This test assumes that there is only 1 package in sample-testng-dp-result that contains tests that add to 12 ms
+      for(TestResults tr : results) {
+    	  tr.tally();
+    	  Map<String, PackageResult> packageResults= tr.getPackageMap();
+    	  for(PackageResult result: packageResults.values()) {
+    		  Assert.assertEquals("org.farshid", result.getName());
+    		  Assert.assertEquals(12, result.getDuration());
+    	  }
+      }
+   }
+
    @Test
    public void testTestngXmlWithNonExistingResultXml() {
       String filename = "/invalid/path/to/file/new-test-result.xml";
       Collection<TestResults> results = ResultsParser.parse(new File(filename), null);
-      Assert.assertTrue("Collection should have been empty. Number of results : " 
+      Assert.assertTrue("Collection should have been empty. Number of results : "
                + results.size(), results.isEmpty());
    }
 


### PR DESCRIPTION
I _think_ the aggregate duration calculations for packages on the index page is currently in-correct (i.e. is always 0/not displayed) .

This commit provides a fix for, and a test to demonstrate the issue.
