### PR TITLE
[FIXED JENKINS-12567] failed tests and configurations shouldn't mark the build as unstable

### DIFF
--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -127,8 +127,7 @@ public class Publisher extends Recorder {
          //create an individual report for all of the results and add it to the build
          TestNGBuildAction action = new TestNGBuildAction(build, results);
          build.getActions().add(action);
-         if (results.getFailedConfigCount() > 0 || results.getSkippedConfigCount() > 0 ||
-                  results.getFailedTestCount() > 0 || results.getSkippedTestCount() > 0) {
+         if (results.getFailedConfigCount() > 0 || results.getFailedTestCount() > 0) {
             build.setResult(Result.UNSTABLE);
          }
       } else {


### PR DESCRIPTION
This is a trivial fix, so I'm sure you could figure this out yourself ;-)
Nevertheless, I've created this pull request.
