### PR TITLE
Use MavenReporter for Maven jobs

### DIFF
--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -3,6 +3,7 @@ package hudson.plugins.testng;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.maven.AbstractMavenProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
 import hudson.model.Result;
@@ -18,6 +19,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
 
@@ -98,7 +100,7 @@ public class Publisher extends Recorder {
       /*
        * filter out the reports based on timestamps. See JENKINS-12187
        */
-      paths = checkReports(build, paths, logger);
+      paths = checkReports(build.getTimestamp(), paths, logger);
 
       boolean filesSaved = saveReports(getTestNGReport(build), paths, logger);
       if (!filesSaved) {
@@ -175,7 +177,7 @@ public class Publisher extends Recorder {
        return new FilePath(new File(build.getRootDir(), "testng"));
    }
 
-   static FilePath[] checkReports(AbstractBuild<?,?> build, FilePath[] paths,
+   static FilePath[] checkReports(Calendar timestamp, FilePath[] paths,
             PrintStream logger)
    {
       List<FilePath> filePathList = new ArrayList<FilePath>(paths.length);
@@ -194,7 +196,7 @@ public class Publisher extends Recorder {
              * dividing by 1000 and comparing because we want to compare secs
              * and not milliseconds
              */
-            if (build.getTimestamp().getTimeInMillis() / 1000 <= report.lastModified() / 1000) {
+            if (timestamp.getTimeInMillis() / 1000 <= report.lastModified() / 1000) {
                filePathList.add(report);
             } else {
                logger.println(report.getName() + " was last modified before "
@@ -259,8 +261,9 @@ public class Publisher extends Recorder {
          return req.bindJSON(Publisher.class, formData);
       }
 
-      public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-         return true;
+      public boolean isApplicable(Class<? extends AbstractProject> projectClass) {
+          
+         return !(AbstractMavenProject.class.isAssignableFrom(projectClass));
       }
    }
 

--- a/src/main/java/hudson/plugins/testng/TestNGAggregatedBuildAction.java
+++ b/src/main/java/hudson/plugins/testng/TestNGAggregatedBuildAction.java
@@ -1,0 +1,128 @@
+package hudson.plugins.testng;
+
+import hudson.maven.AggregatableAction;
+import hudson.maven.MavenAggregatedReport;
+import hudson.maven.MavenBuild;
+import hudson.maven.MavenModule;
+import hudson.maven.MavenModuleSet;
+import hudson.maven.MavenModuleSetBuild;
+import hudson.model.Action;
+import hudson.plugins.testng.results.TestResults;
+
+import java.lang.ref.WeakReference;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class TestNGAggregatedBuildAction extends TestNGBuildAction implements MavenAggregatedReport {
+
+    private static final long serialVersionUID = 1L;
+    private MavenModuleSetBuild mmsb;
+    
+    
+    private transient boolean testResultsInitialized = false;
+    
+    private static final TestResults DUMMY_RESULT = new TestResults("$$TestNGAggregatedBuildAction-dummy$$");
+
+    public TestNGAggregatedBuildAction(MavenModuleSetBuild build) {
+        super(build, DUMMY_RESULT); // pass a dummy result up to make the that results are calculated
+        // on the 1st #getResults call
+        this.mmsb = build;
+    }
+    
+    @Override
+    public TestResults getResults() {
+        if (testResults == null) {
+            testResults = new WeakReference<TestResults>(aggregateResults(this.mmsb));
+            return testResults.get();
+         }
+
+         TestResults tr = testResults.get();
+         if (tr == null || tr.getName().equals(DUMMY_RESULT.getName())) {
+            testResults = new WeakReference<TestResults>(aggregateResults(this.mmsb));
+           return testResults.get();
+         } else{
+           return tr;
+         }
+    }
+    
+    @Override
+    public int getPassedTestCount() {
+        if (!testResultsInitialized) {
+            getResults();
+        }
+        
+        return super.getPassedTestCount();
+    }
+
+    @Override
+    public int getFailedTestCount() {
+        if (!testResultsInitialized) {
+            getResults();
+        }
+        
+        return super.getFailedTestCount();
+    }
+
+    @Override
+    public int getSkippedTestCount() {
+        if (!testResultsInitialized) {
+            getResults();
+        }
+        
+        return super.getSkippedTestCount();
+    }
+
+    private TestResults aggregateResults(MavenModuleSetBuild build) {
+        
+        Map<MavenModule, MavenBuild> moduleLastBuilds = build.getModuleLastBuilds();
+        
+        TestResults aggregatedResults = new TestResults(UUID.randomUUID().toString());
+        for (MavenBuild mb : moduleLastBuilds.values()) {
+            if (mb.getAction(TestNGBuildAction.class) != null) {
+                TestNGBuildAction action = mb.getAction(TestNGBuildAction.class);
+                TestResults moduleResults = action.getResults();
+                
+                aggregatedResults.add(moduleResults);
+            }
+        }
+        
+        aggregatedResults.tally();
+        
+        passedTestCount = aggregatedResults.getPassedTestCount();
+        failedTestCount = aggregatedResults.getFailedTestCount();
+        skippedTestCount = aggregatedResults.getSkippedTestCount();
+        
+        testResultsInitialized = true;
+        
+        return aggregatedResults;
+    }
+
+    public void update(Map<MavenModule, List<MavenBuild>> moduleBuilds,
+            MavenBuild newBuild) {
+    }
+
+    public Class<? extends AggregatableAction> getIndividualActionType() {
+        return TestNGBuildAction.class;
+    }
+
+    public Action getProjectAction(MavenModuleSet moduleSet) {
+        return new TestNGProjectAction(moduleSet, true, true); // TODO: how to take the configured values for escapeTestDescp, escapeExceptionMsg?
+    }
+
+    
+    protected Object readResolve() {
+     // The following doesn't work, because the module list is not initialized, yet, so aggregateResults
+        // would return an empty TestResults
+        
+//       TestResults testResults = getResults();
+//
+//       //initialize the cached values
+//       passedTestCount = testResults.getPassedTestCount();
+//       failedTestCount = testResults.getFailedTestCount();
+//       skippedTestCount = testResults.getSkippedTestCount();
+
+       return this;
+    }
+
+}

--- a/src/main/java/hudson/plugins/testng/TestNGMavenReporter.java
+++ b/src/main/java/hudson/plugins/testng/TestNGMavenReporter.java
@@ -1,0 +1,221 @@
+package hudson.plugins.testng;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.maven.MavenBuildProxy;
+import hudson.maven.MavenBuildProxy.BuildCallable;
+import hudson.maven.MavenReporter;
+import hudson.maven.MavenReporterDescriptor;
+import hudson.maven.MojoInfo;
+import hudson.maven.MavenBuild;
+import hudson.maven.MavenModule;
+import hudson.maven.reporters.Messages;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.model.AbstractBuild;
+import hudson.plugins.testng.results.TestResults;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+
+public class TestNGMavenReporter extends MavenReporter {
+    
+    // TODO: better use this one than the one in TestNGAggregatedBuildAction?
+//    @Override
+//    public Action getAggregatedProjectAction(MavenModuleSet project) {
+//        return new TestNGProjectAction(project, false, false); // TOD escapeTestDescp, escapeExceptionMsg));
+//    }
+    
+    public Collection<? extends Action> getProjectActions(MavenModule module) {
+        return Collections.singletonList(
+                new TestNGProjectAction(module, true, true));
+    }
+    
+    @Override
+    public boolean postExecute(MavenBuildProxy build, MavenProject pom,
+            MojoInfo mojo, final BuildListener listener, Throwable error)
+            throws InterruptedException, IOException {
+        if (!isATestRunMojo(mojo)) return true;
+        
+        build.registerAsProjectAction(this);
+
+        PrintStream logger = listener.getLogger();
+
+        File reportsDir;
+        if (mojo.is("org.apache.maven.plugins", "maven-surefire-plugin", "test") ||
+            mojo.is("org.apache.maven.plugins", "maven-failsafe-plugin", "integration-test")) {
+            try {
+                reportsDir = mojo.getConfigurationValue("reportsDirectory", File.class);
+            } catch (ComponentConfigurationException e) {
+                e.printStackTrace(listener.fatalError(Messages.SurefireArchiver_NoReportsDir()));
+                build.setResult(Result.FAILURE);
+                return true;
+            }
+        }
+        else {
+            reportsDir = new File(pom.getBasedir(), "target/surefire-reports");
+        }
+
+        if(reportsDir.isDirectory()) {
+
+            synchronized (build) {
+                
+                FilePath reportsPath = new FilePath(reportsDir);
+                
+                FilePath[] paths = Publisher.locateReports(reportsPath, "testng-results.xml");
+                
+                
+                if (paths.length == 0) {
+                    logger.println("Did not find any matching files.");
+                    //build can still continue
+                    return true;
+                 }
+                
+                /*
+                 * filter out the reports based on timestamps. See JENKINS-12187
+                 */
+                paths = Publisher.checkReports(build.getTimestamp(), paths, logger);
+                
+                
+                boolean filesSaved = Publisher.saveReports(getTestNGReport(build.getRootDir()), paths, logger);
+                if (!filesSaved) {
+                   logger.println("Failed to save TestNG XML reports");
+                   return true;
+                }
+                
+                build.execute(new BuildCallable<Boolean, IOException>() {
+                        private static final long serialVersionUID = 1L;
+                        public Boolean call(MavenBuild build) throws IOException, InterruptedException {
+                            Action a = createTestNGBuildAction(build, listener);
+                            if (a != null) {
+                                build.addAction(a);
+                            }
+                            return Boolean.TRUE;
+                        }
+                });
+
+                logger.println("TestNG Reports Processing: FINISH");
+                return true;
+           }
+        }
+
+        return true;
+    }
+    
+    public static TestNGBuildAction createTestNGBuildAction(AbstractBuild<?, ?> build, BuildListener listener) {
+        PrintStream logger = listener.getLogger();
+        TestResults results = new TestResults("");
+        try {
+           results = TestNGBuildAction.loadResults(build, logger);
+        } catch (Throwable t) {
+           /*
+            * don't fail build if TestNG parser barfs.
+            * only print out the exception to console.
+            */
+           t.printStackTrace(logger);
+        }
+
+        if (results.getTestList().size() > 0) {
+           //create an individual report for all of the results and add it to the build
+           TestNGBuildAction action = new TestNGBuildAction(build, results);
+           if (results.getFailedConfigCount() > 0 || results.getFailedTestCount() > 0) {
+              build.setResult(Result.UNSTABLE);
+           }
+           return action;
+        } else {
+           logger.println("Found matching files but did not find any TestNG results.");
+        }
+        return null;
+    }
+        
+    /**
+     * Gets the directory to store report files
+     */
+    static FilePath getTestNGReport(FilePath rootDir) {
+        return new FilePath(rootDir, "testng");
+    }
+    
+    private static boolean isATestRunMojo(MojoInfo mojo) {
+        if ((!mojo.is("com.sun.maven", "maven-junit-plugin", "test"))
+            && (!mojo.is("org.sonatype.flexmojos", "flexmojos-maven-plugin", "test-run"))
+            && (!mojo.is("org.eclipse.tycho", "tycho-surefire-plugin", "test"))
+            && (!mojo.is("org.sonatype.tycho", "maven-osgi-test-plugin", "test"))
+            && (!mojo.is("org.codehaus.mojo", "gwt-maven-plugin", "test"))
+            && (!mojo.is("org.apache.maven.plugins", "maven-surefire-plugin", "test"))
+            && (!mojo.is("org.apache.maven.plugins", "maven-failsafe-plugin", "integration-test")))
+            return false;
+
+        try {
+            if (mojo.is("org.apache.maven.plugins", "maven-surefire-plugin", "test")) {
+                Boolean skip = mojo.getConfigurationValue("skip", Boolean.class);
+                if (((skip != null) && (skip))) {
+                    return false;
+                }
+                
+                if (mojo.pluginName.version.compareTo("2.3") >= 0) {
+                    Boolean skipExec = mojo.getConfigurationValue("skipExec", Boolean.class);
+                    
+                    if (((skipExec != null) && (skipExec))) {
+                        return false;
+                    }
+                }
+                
+                if (mojo.pluginName.version.compareTo("2.4") >= 0) {
+                    Boolean skipTests = mojo.getConfigurationValue("skipTests", Boolean.class);
+                    
+                    if (((skipTests != null) && (skipTests))) {
+                        return false;
+                    }
+                }
+            }
+            else if (mojo.is("com.sun.maven", "maven-junit-plugin", "test")) {
+                Boolean skipTests = mojo.getConfigurationValue("skipTests", Boolean.class);
+                
+                if (((skipTests != null) && (skipTests))) {
+                    return false;
+                }
+            }
+            else if (mojo.is("org.sonatype.flexmojos", "flexmojos-maven-plugin", "test-run")) {
+                Boolean skipTests = mojo.getConfigurationValue("skipTest", Boolean.class);
+                if (((skipTests != null) && (skipTests))) {
+                    return false;
+                }
+            } else if (mojo.is("org.sonatype.tycho", "maven-osgi-test-plugin", "test")) {
+                Boolean skipTests = mojo.getConfigurationValue("skipTest", Boolean.class);
+                if (((skipTests != null) && (skipTests))) {
+                    return false;
+                }
+            } else if (mojo.is("org.eclipse.tycho", "tycho-surefire-plugin", "test")) {
+                Boolean skipTests = mojo.getConfigurationValue("skipTest", Boolean.class);
+                if (((skipTests != null) && (skipTests))) {
+                    return false;
+                }
+            }
+
+        } catch (ComponentConfigurationException e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends MavenReporterDescriptor {
+        public String getDisplayName() {
+            return "Publish " + PluginImpl.DISPLAY_NAME;
+        }
+
+        public TestNGMavenReporter newAutoInstance(MavenModule module) {
+            return new TestNGMavenReporter();
+        }
+    }
+
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/hudson/plugins/testng/results/TestResults.java
+++ b/src/main/java/hudson/plugins/testng/results/TestResults.java
@@ -43,6 +43,18 @@ public class TestResults extends BaseResult implements Serializable {
    public TestResults(String name) {
       super(name);
    }
+   
+   /**
+    * Needed to aggregate several {@link TestResults}.
+    */
+   public void add(TestResults other) {
+       this.testList.addAll(other.getTestList());
+       this.failedTests.addAll(other.getFailedTests());
+       this.passedTests.addAll(other.getPassedTests());
+       this.skippedTests.addAll(other.getSkippedTests());
+       this.skippedConfigurationMethods.addAll(other.getSkippedConfigs());
+       this.failedConfigurationMethods.addAll(other.getFailedConfigs());
+   }
 
    public List<MethodResult> getFailedTests() {
       return failedTests;


### PR DESCRIPTION
This pull request implements a TestNGMavenReporter for Maven jobs. Note that the implementation is not 100% complete, yet (see below for open points). This pull request is just for asking for initial feedback about the new  feature.

Advantages of using the MavenReporter:
- faster location of the results files as not the whole workspace has to be scanned, but only the surefire report dirs
- in a multi-module build provides per-module TestNG results and graphs

What's still missing:
- reporter is not configurable, yet, i.e. cannot be disabled
- escapeTestDescp and escapeExceptionMsg are not respected, yet
- migration of old projects not tested, yet. Not sure if any work is needed for migration.
- there's a lot of code duplication between Publisher and TestNGMavenReporter which I'd like to remove
- unit tests
- Javadoc