### PR TITLE
Fix for JENKINS-10832

### DIFF
--- a/src/main/java/hudson/plugins/testng/results/MethodResult.java
+++ b/src/main/java/hudson/plugins/testng/results/MethodResult.java
@@ -36,6 +36,7 @@ public class MethodResult extends BaseResult {
    private String parentSuiteName;
    private List<String> groups;
    private List<String> parameters;
+   private List<String> reporterOutputLines;
 
    /**
     * unique id for this tests's run (helps associate the test method with
@@ -393,5 +394,31 @@ public class MethodResult extends BaseResult {
          }
       }
       return "result-passed";
+   }
+
+   /**
+    * 
+    */
+   public void setReporterOutputLines(final List<String> reporterOutputLines)
+   {
+       this.reporterOutputLines = reporterOutputLines;
+   }
+   
+   /**
+    * @return
+    */
+   public List<String> getReporterOuputLines()
+   {
+       return reporterOutputLines;
+   }
+   
+   public String getDisplayReporterOutputLines()
+   {
+       StringBuffer sb = new StringBuffer();
+       for (String line : reporterOutputLines)
+       {
+           sb.append("<p>").append(line).append("</p>");
+       }
+       return sb.toString();
    }
 }

--- a/src/main/resources/hudson/plugins/testng/results/MethodResult/reportDetail.jelly
+++ b/src/main/resources/hudson/plugins/testng/results/MethodResult/reportDetail.jelly
@@ -20,6 +20,14 @@
       Group(s): ${it.displayGroups}
    </j:if>
 
+
+   <div style="margin: 20px">
+     <p><b>Reporter Output:</b></p>
+     <div>
+         ${it.displayReporterOutputLines}
+     </div>
+   </div>
+
    <j:if test="${!empty(it.parameters)}">
       <table border="1px" class="pane">
          <thead>

--- a/src/test/java/hudson/plugins/testng/parser/TestParser.java
+++ b/src/test/java/hudson/plugins/testng/parser/TestParser.java
@@ -95,4 +95,26 @@ public class TestParser {
       SimpleDateFormat sdf = new SimpleDateFormat(ResultsParser.DATE_FORMAT);
       sdf.parse(dateString);
    }
+   
+   @Test
+   public void testReporterLogParser() throws ParseException {
+       String filename = "sample-testng-reporter-log-result.xml";
+       URL resource = TestParser.class.getClassLoader().getResource(filename);
+       Assert.assertNotNull(resource);
+       TestResults results = getResults(resource.getFile());
+       Assert.assertFalse("Collection shouldn't have been empty", results.getTestList().isEmpty());
+       Assert.assertEquals(1, results.getTestList().size());
+       results.tally();
+       Assert.assertEquals(1, results.getPackageNames().size());
+       Assert.assertEquals(1, results.getPackageMap().values().iterator().next().getClassList().size());
+       Assert.assertEquals(1, results.getPassedTestCount());
+       Assert.assertEquals(1, results.getPassedTests().size());
+       Assert.assertEquals(1, results.getFailedTests().size());
+       Assert.assertNotNull(results.getFailedTests().get(0).getException());
+       Assert.assertNotNull(results.getFailedTests().get(0).getReporterOuputLines());
+       Assert.assertEquals(2, results.getFailedTests().get(0).getReporterOuputLines().size());
+       Assert.assertEquals("Some Reporter.log() statement", results.getFailedTests().get(0).getReporterOuputLines().get(0));
+       Assert.assertEquals("Another Reporter.log() statement", results.getFailedTests().get(0).getReporterOuputLines().get(1));
+       Assert.assertEquals(0, results.getPassedTests().get(0).getReporterOuputLines().size());
+   }
 }

--- a/src/test/resources/sample-testng-reporter-log-result.xml
+++ b/src/test/resources/sample-testng-reporter-log-result.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testng-results skipped="4" failed="35" total="502" passed="463">
+  <reporter-output>
+    <line>
+      <![CDATA[Some Reporter.log() statement]]>
+    </line>
+  </reporter-output>
+  <suite name="Sample Test Suite" duration-ms="1412694" started-at="2012-11-27T20:52:54Z" finished-at="2012-11-27T21:16:27Z">
+    <groups>
+      <group name="single-threaded">
+          <method signature="ExampleIntegrationTest.FirstTest()[pri:0, instance:org.example.test.ExampleIntegrationTest@682f8c99]" name="FirstTest" class="org.example.test.ExampleIntegrationTest"/>
+          <method signature="ExampleIntegrationTest.SecondTest()[pri:0, instance:org.example.test.ExampleIntegrationTest@682f8c99]" name="SecondTest" class="org.example.test.ExampleIntegrationTest"/>
+      </group> <!-- single-threaded -->
+    </groups>
+    <test name="Single-Threaded Tests" duration-ms="953016" started-at="2012-11-27T20:52:54Z" finished-at="2012-11-27T21:08:47Z">
+      <class name="org.example.test.ExampleIntegrationTest">
+        <test-method status="PASS" signature="beforeClass()[pri:0, instance:org.example.test.ExampleIntegrationTest@682f8c99]" name="beforeClass" is-config="true" duration-ms="10793" started-at="2012-11-27T21:04:44Z" finished-at="2012-11-27T21:04:55Z">
+          <reporter-output>
+          </reporter-output>
+        </test-method> <!-- beforeClass -->
+        <test-method status="PASS" signature="beforeMethod()[pri:0, instance:org.example.test.ExampleIntegrationTest@682f8c99]" name="beforeMethod" is-config="true" duration-ms="20" started-at="2012-11-27T21:04:55Z" finished-at="2012-11-27T21:04:55Z">
+          <reporter-output>
+          </reporter-output>
+        </test-method> <!-- beforeMethod -->
+        <test-method status="FAIL" signature="FirstTest()[pri:0, instance:org.example.test.ExampleIntegrationTest@682f8c99]" name="FirstTest" duration-ms="12972" started-at="2012-11-27T21:04:55Z" finished-at="2012-11-27T21:05:08Z">
+          <exception class="java.lang.AssertionError">
+            <full-stacktrace>
+              <![CDATA[java.lang.AssertionError
+    at org.farshid.TestDataProvider.test(TestDataProvider.java:15)
+    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
+    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
+    at java.lang.reflect.Method.invoke(Method.java:597)
+    at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:74)
+    at org.testng.internal.Invoker.invokeMethod(Invoker.java:673)
+    at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:846)
+    at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1170)
+    at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
+    at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
+    at org.testng.TestRunner.runWorkers(TestRunner.java:1125)
+    at org.testng.TestRunner.privateRun(TestRunner.java:749)
+    at org.testng.TestRunner.run(TestRunner.java:600)
+    at org.testng.SuiteRunner.runTest(SuiteRunner.java:317)
+    at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:312)
+    at org.testng.SuiteRunner.privateRun(SuiteRunner.java:274)
+    at org.testng.SuiteRunner.run(SuiteRunner.java:223)
+    at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
+    at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
+    at org.testng.TestNG.runSuitesSequentially(TestNG.java:1007)
+    at org.testng.TestNG.runSuitesLocally(TestNG.java:932)
+    at org.testng.TestNG.run(TestNG.java:868)
+    at org.testng.TestNG.privateMain(TestNG.java:1150)
+    at org.testng.TestNG.main(TestNG.java:1114)
+]]>
+            </full-stacktrace>
+          </exception>
+          <reporter-output>
+            <line>
+              <![CDATA[Some Reporter.log() statement]]>
+            </line>
+            <line>
+              <![CDATA[Another Reporter.log() statement]]>
+            </line>
+          </reporter-output>
+        </test-method> <!-- ExampleIntegrationTest -->
+        <test-method status="PASS" signature="SecondTest()[pri:0, instance:org.example.test.ExampleIntegrationTest@682f8c99]" name="SecondTest" duration-ms="0" started-at="2011-03-09T21:13:15Z" finished-at="2011-03-09T21:13:15Z">
+          <reporter-output>
+          </reporter-output>
+        </test-method>
+      </class>
+    </test>
+  </suite>
+</testng-results>


### PR DESCRIPTION
Make reporter-output visible in test method result. Works with testng
6.7+ which include reporter-output alongside test method result
data in testng-results.xml
