### PR TITLE
Add failure age to test result overview page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>testng-plugin</artifactId>
-    <version>1.6</version>
+    <version>1.7-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>TestNG Results Plugin</name>
 

--- a/src/main/java/hudson/plugins/testng/results/MethodResult.java
+++ b/src/main/java/hudson/plugins/testng/results/MethodResult.java
@@ -417,4 +417,31 @@ public class MethodResult extends BaseResult {
     public boolean hasChildren() {
         return false;
     }
+    
+    @Override
+    public int getFailedSince() {
+        MethodResult result = this;
+        int lastFailure = owner.getNumber();
+        
+        while (result != null && result.getStatus().equals("FAIL")) {
+            lastFailure = result.getOwner().getNumber();
+            
+            result = (MethodResult) result.getPreviousResult();
+        }
+        
+        return lastFailure;
+    }
+    
+    public long getFailAge() {
+        long failAge = 0;
+        MethodResult result = this;
+        
+        while (result != null && result.getStatus().equals("FAIL")) {
+            failAge++;
+            
+            result = (MethodResult) result.getPreviousResult();
+        }
+        
+        return failAge;
+    }
 }

--- a/src/main/resources/hudson/plugins/testng/TestNGTestResultBuildAction/reportDetail.groovy
+++ b/src/main/resources/hudson/plugins/testng/TestNGTestResultBuildAction/reportDetail.groovy
@@ -25,6 +25,9 @@ if (my.result.failCount != 0) {
                 th(class: "pane-header") {
                     text("Duration")
                 }
+                th(class: "pane-header") {
+                    test("Age")
+                }
             }
         }
         tbody() {
@@ -47,6 +50,9 @@ if (my.result.failCount != 0) {
                     }
                     td(align: "right") {
                         text("${FormatUtil.formatTime(failedTest.duration)}")
+                    }
+                    td(align: "right") {
+                        text("${failedTest.failAge}")
                     }
                 }
             }


### PR DESCRIPTION
The default JUnit reporting plugin reports for how many subsequent builds a test has been failing. I missed that feature on this plugin, so I've added it. Please review and comment if there are any improvements I can make.