### PR TITLE
Fix default value of testng.reportFilenamePattern

### DIFF
--- a/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
+++ b/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
@@ -1,7 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:bh="/lib/health">
    <f:entry title="TestNG XML report pattern" field="reportFilenamePattern">
-      <f:textbox name="testng.reportFilenamePattern" value="${instance.reportFilenamePattern}" default="**/testng-result.xml"/>
+      <f:textbox name="testng.reportFilenamePattern" value="${instance.reportFilenamePattern}" default="**/testng-results.xml"/>
    </f:entry>
    <f:advanced>
       <f:entry title="Escape Test description string?" field="escapeTestDescp">


### PR DESCRIPTION
The default filename is "testng-results.xml". See [the sources of TestNG](https://github.com/cbeust/testng/blob/bd1e7d431b9a108ffe1b42f2976756e4b372cfb3/src/main/java/org/testng/reporters/XMLReporter.java#L29).
