### PR TITLE
Removing gratuitous dependency on maven-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>maven-plugin</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.8.5</version>


### PR DESCRIPTION
Looks like https://github.com/jenkinsci/testng-plugin-plugin/commit/a9b873e6f0d3106f3567ef8ac711f2d6eb32105c (over three years ago!) forgot to remove the POM dependency, and thus the plugin dependency.
