### PR TITLE
Retain white-space formatting in reporter output.

### DIFF
--- a/src/main/resources/hudson/plugins/testng/results/MethodResult/reportDetail.groovy
+++ b/src/main/resources/hudson/plugins/testng/results/MethodResult/reportDetail.groovy
@@ -76,7 +76,7 @@ div(id: "report") {
     if (my.reporterOutput) {
         div(id: "reporter-output") {
             h3("Reporter Output")
-            code(style: "margin-left:15px; display:block; border:1px black; background-color:#F0F0F0; width:800px") {
+            code(style: "white-space:pre; margin-left:15px; display:block; border:1px black; background-color:#F0F0F0") {
                 raw("${my.reporterOutput}")
             }
         }


### PR DESCRIPTION
We use white space in formatting test output.  This change renders reporter output as <pre>.
