### PR TITLE
TestConfigFailure: Add property to fail build on config fail

### DIFF
--- a/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
+++ b/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
@@ -13,8 +13,11 @@
       <f:entry title="Show failed builds in trend graph?" field="showFailedBuilds">
          <f:checkbox name="testng.showFailedBuilds" default="false" />
       </f:entry>
-      <f:entry title="Mark build unstable on skipped tests?" field="unstableOnSkippedTests">
+      <f:entry title="Mark build as unstable on skipped tests?" field="unstableOnSkippedTests">
          <f:checkbox name="testng.unstableOnSkippedTests" default="false" />
+      </f:entry>
+      <f:entry title="Mark build as failure on failed configuration?" field="failureOnFailedTestConfig">
+         <f:checkbox name="testng.failureOnFailedTestConfig" default="false" />
       </f:entry>
    </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-failureOnFailedTestConfig.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-failureOnFailedTestConfig.html
@@ -1,0 +1,5 @@
+<div>
+    <b>Mark as failure on Failed Test Configuration Methods</b>
+    <p>Allows for a distinction between failing tests and failing configuration methods.
+        Failing tests can be seen as an unstable build whereas failing configuration methods are a failed build</p>
+</div>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-unstableOnSkippedTests.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-unstableOnSkippedTests.html
@@ -1,5 +1,5 @@
 <div>
-   <b>Mark unstable on Skipped Configuration/Test Methods</b>
-   <p>Marks the build unstable of skipped configuration or test methods are found in results.
+   <b>Mark as unstable on Skipped Configuration/Test Methods</b>
+   <p>Marks the build as unstable if skipped configuration or test methods are found in results.
        If build result is worse that UNSTABLE, this option has no effect</p>
 </div>

--- a/src/test/java/hudson/plugins/testng/Constants.java
+++ b/src/test/java/hudson/plugins/testng/Constants.java
@@ -52,4 +52,8 @@ public class Constants {
      * Contains 1 passed and 1 skipped test
      */
     public static final String TESTNG_SKIPPED_TEST = "testng-skipped-tests.xml";
+    /**
+     * Contains 1 failed config and 1 skipped test
+     */
+    public static final String TESTNG_FAILED_TEST_CONFIG = "testng-failed-test-config.xml";
 }

--- a/src/test/java/hudson/plugins/testng/PublisherCtor.java
+++ b/src/test/java/hudson/plugins/testng/PublisherCtor.java
@@ -12,9 +12,11 @@ public class PublisherCtor {
     private boolean escapeTestDescp = true;
     private boolean showFailedBuilds = false;
     private boolean unstableOnSkippedTests = false;
+    private boolean failureOnFailedTestConfig = false;
 
     public Publisher getNewPublisher() {
-        return new Publisher(reportFilenamePattern, escapeTestDescp, escapeExceptionMsg, showFailedBuilds, unstableOnSkippedTests);
+        return new Publisher(reportFilenamePattern, escapeTestDescp, escapeExceptionMsg, showFailedBuilds,
+                unstableOnSkippedTests, failureOnFailedTestConfig);
     }
 
     public PublisherCtor setReportFilenamePattern(String reportFilenamePattern) {
@@ -39,6 +41,11 @@ public class PublisherCtor {
 
     public PublisherCtor setUnstableOnSkippedTests(boolean unstableOnSkippedTests) {
         this.unstableOnSkippedTests = unstableOnSkippedTests;
+        return this;
+    }
+
+    public PublisherCtor setFailureOnFailedTestConfig(boolean failureOnFailedTestConfig) {
+        this.failureOnFailedTestConfig = failureOnFailedTestConfig;
         return this;
     }
 }

--- a/src/test/java/hudson/plugins/testng/PublisherTest.java
+++ b/src/test/java/hudson/plugins/testng/PublisherTest.java
@@ -91,7 +91,7 @@ public class PublisherTest extends HudsonTestCase {
     @Test
     public void testRoundTrip() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
-        Publisher before = new Publisher("", false, false, true, true);
+        Publisher before = new Publisher("", false, false, true, true, true);
         p.getPublishersList().add(before);
 
         submit(createWebClient().getPage(p,"configure").getFormByName("config"));

--- a/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
+++ b/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
@@ -279,5 +279,50 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
         Assert.assertSame(Result.FAILURE, build.getResult());
     }
 
+    @Test
+    public void test_failed_config_default_setting() throws Exception {
+        FreeStyleProject p = createFreeStyleProject();
+        PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml");
+        Publisher publisher = publisherCtor.getNewPublisher();
+        p.getPublishersList().add(publisher);
+        p.onCreatedFromScratch(); //to setup project action
+
+        p.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                                   BuildListener listener) throws InterruptedException, IOException {
+                String contents = CommonUtil.getContents(Constants.TESTNG_FAILED_TEST_CONFIG);
+                build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
+                return true;
+            }
+        });
+
+        //run build
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        Assert.assertSame(Result.UNSTABLE, build.getResult());
+    }
+
+    @Test
+    public void test_failed_config_enabled_failedbuild() throws Exception {
+        FreeStyleProject p = createFreeStyleProject();
+        PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
+                .setFailureOnFailedTestConfig(true);
+        Publisher publisher = publisherCtor.getNewPublisher();
+        p.getPublishersList().add(publisher);
+        p.onCreatedFromScratch(); //to setup project action
+
+        p.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                                   BuildListener listener) throws InterruptedException, IOException {
+                String contents = CommonUtil.getContents(Constants.TESTNG_FAILED_TEST_CONFIG);
+                build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
+                return true;
+            }
+        });
+
+        //run build
+        FreeStyleBuild build = p.scheduleBuild2(0).get();
+        Assert.assertSame(Result.FAILURE, build.getResult());
+    }
+
 
 }

--- a/src/test/resources/testng-failed-test-config.xml
+++ b/src/test/resources/testng-failed-test-config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testng-results skipped="0" failed="0" total="121" passed="121">
+    <reporter-output>
+    </reporter-output>
+    <suite name="Failed Test Method Config suite" duration-ms="23913" started-at="2012-01-23T10:51:27Z" finished-at="2012-01-23T10:51:51Z">
+        <groups>
+        </groups>
+        <test name="Failed Test Config Method test" duration-ms="23913" started-at="2012-01-23T10:51:27Z" finished-at="2012-01-23T10:51:51Z">
+            <class name="com.fakepkg.test.MyFakeTest">
+                <test-method status="FAIL" signature="testSetup" name="testSetup" is-config="true" duration-ms="11" started-at="2012-01-23T10:51:51Z" finished-at="2012-01-23T10:51:51Z" />
+                <test-method status="SKIP" signature="runTest" name="testShouldPass" duration-ms="11" started-at="2012-01-23T10:51:51Z" finished-at="2012-01-23T10:51:51Z" />
+            </class>
+        </test>
+    </suite>
+</testng-results>


### PR DESCRIPTION
It can be useful to make a distinction between test failures and test config
method  failures.
Test failures can mark the build as unstable as typically a build has executed
correctly  if there are only test failures.
Test method failures (beforeMethod, afterMethod etc.) are signs that something
big  went wrong and so the build should be marked as failure.