### PR TITLE
JENKINS-20985 Add functionality for setting fail/skip thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/*
 .settings/
 .classpath
 .project
+/target/

--- a/README
+++ b/README
@@ -15,6 +15,8 @@ graph and all details about which tests that failed are also presented.
 
 Release Notes
 -------
+### 1.12
+* Added: Add ability to configure failed/skipped test thresholds
 
 ### 1.10
 * Upped compatible Jenkins version to v1.554.3

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>testng-plugin</artifactId>
-    <version>1.11-SNAPSHOT</version>
+    <version>1.12-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>TestNG Results Plugin</name>
 

--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -39,9 +39,15 @@ public class Publisher extends Recorder {
    public final boolean escapeExceptionMsg;
    //should failed builds be included in graphs or not
    public final boolean showFailedBuilds;
+   //True to use thresholds
+   //skipped tests mark build as unstable
+   public final boolean unstableOnSkippedTests;
+   //failed config mark build as failure
+   public final boolean failureOnFailedTestConfig;
+   public final boolean useThresholds;
    //number of skips that will trigger "Unstable"
    public final int unstableSkips;
-    //number of fails that will trigger "Unstable"
+   //number of fails that will trigger "Unstable"
    public final int unstableFails;
    //number of skips that will trigger "Failed"
    public final int failedSkips;
@@ -55,18 +61,20 @@ public class Publisher extends Recorder {
 
    @DataBoundConstructor
    public Publisher(String reportFilenamePattern, boolean escapeTestDescp, boolean escapeExceptionMsg,
-                    boolean showFailedBuilds, int unstableSkips, int unstableFails, int failedSkips, int failedFails, boolean usePercentage) {
+                    boolean showFailedBuilds, boolean unstableOnSkippedTests, boolean failureOnFailedTestConfig, boolean useThresholds,
+                    int unstableSkips, int unstableFails, int failedSkips, int failedFails, boolean usePercentage) {
       this.reportFilenamePattern = reportFilenamePattern;
       this.escapeTestDescp = escapeTestDescp;
       this.escapeExceptionMsg = escapeExceptionMsg;
       this.showFailedBuilds = showFailedBuilds;
+      this.unstableOnSkippedTests = unstableOnSkippedTests;
+      this.failureOnFailedTestConfig = failureOnFailedTestConfig;
+      this.useThresholds = useThresholds;
       this.unstableSkips = unstableSkips;
       this.unstableFails = unstableFails;
       this.failedSkips = failedSkips;
       this.failedFails = failedFails;
       this.usePercentage = usePercentage;
-      //this.unstableOnSkippedTests = unstableOnSkippedTests;
-      //this.failureOnFailedTestConfig = failureOnFailedTestConfig;
    }
 
    public BuildStepMonitor getRequiredMonitorService() {
@@ -145,14 +153,27 @@ public class Publisher extends Recorder {
       if (results.getTestList().size() > 0) {
          //create an individual report for all of the results and add it to the build
          build.addAction(new TestNGTestResultBuildAction(results));
-         if(usePercentage) {
-            //TODO add logic for using percentages
+         if(useThresholds) {
+            if(usePercentage) {
+               //TODO add logic for using percentages
+            } else {
+               if (results.getFailCount() >= failedFails || results.getSkipCount() >= failedSkips) {
+                  logger.println("Failed Tests exceeded threshold of " + failedFails + " or Skipped Tests exceeded threshold of " + failedSkips + ". Marking build as FAILURE.");
+                  build.setResult(Result.FAILURE);
+               } else if (results.getFailCount() >= unstableFails || results.getSkipCount() >= unstableSkips) {
+                  logger.println("Failed Tests exceeded threshold of " + unstableFails + " or Skipped Tests exceeded threshold of " + unstableSkips + ". Marking build as UNSTABLE.");
+                  build.setResult(Result.UNSTABLE);
+               }
+            }
          } else {
-            if (results.getFailCount() >= failedFails || results.getSkipCount() >= failedSkips) {
-                logger.println("Failed Tests exceeded threshold of " + failedFails + " or Skipped Tests exceeded threshold of " + failedSkips + ". Marking build as FAILURE.");
-                build.setResult(Result.FAILURE);
-            } else if (results.getFailCount() >= unstableFails || results.getSkipCount() >= unstableSkips) {
-               logger.println("Failed Tests exceeded threshold of " + unstableFails + " or Skipped Tests exceeded threshold of " + unstableSkips + ". Marking build as UNSTABLE.");
+            if (failureOnFailedTestConfig && results.getFailedConfigCount() > 0) {
+               logger.println("Failed configuration methods found. Marking build as FAILURE.");
+               build.setResult(Result.FAILURE);
+            } else if (unstableOnSkippedTests && (results.getSkippedConfigCount() > 0 || results.getSkipCount() > 0)) {
+               logger.println("Skipped Tests/Configs found. Marking build as UNSTABLE.");
+               build.setResult(Result.UNSTABLE);
+            } else if (results.getFailedConfigCount() > 0 || results.getFailCount() > 0) {
+               logger.println("Failed Tests/Configs found. Marking build as UNSTABLE.");
                build.setResult(Result.UNSTABLE);
             }
          }

--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -149,22 +149,34 @@ public class Publisher extends Recorder {
             logger.println("Failed configuration methods found. Marking build as FAILURE.");
             build.setResult(Result.FAILURE);
          } else {
-        	 if (thresholdMode == 1) {
-        		 if (results.getFailCount() >= failedFails || results.getSkipCount() >= failedSkips) {
-        			 logger.println("Failed Tests exceeded threshold of " + failedFails + " or Skipped Tests exceeded threshold of " + failedSkips + ". Marking build as FAILURE.");
+        	 if (thresholdMode == 1) { //number of tests
+        		 if (results.getFailCount() > failedFails)  {
+        			 logger.println(String.format("%d tests failed, which exceeded threshold of %d. Marking build as FAILURE", results.getFailCount(), failedFails)); 
         			 build.setResult(Result.FAILURE);
-        		 } else if (results.getFailCount() >= unstableFails || results.getSkipCount() >= unstableSkips) {
-        			 logger.println("Failed Tests exceeded threshold of " + unstableFails + " or Skipped Tests exceeded threshold of " + unstableSkips + ". Marking build as UNSTABLE.");
+        		 } else if (results.getSkipCount() > failedSkips) {
+        			 logger.println(String.format("%d tests were skipped, which exceeded threshold of %d. Marking build as FAILURE", results.getSkipCount(), failedSkips)); 
+        			 build.setResult(Result.FAILURE);
+        		 } else if (results.getFailCount() > unstableFails) {
+        			 logger.println(String.format("%d tests failed, which exceeded threshold of %d. Marking build as UNSTABLE", results.getFailCount(), unstableFails)); 
+        			 build.setResult(Result.UNSTABLE);
+        		 } else if (results.getSkipCount() > unstableSkips) {
+        			 logger.println(String.format("%d tests were skipped, which exceeded threshold of %d. Marking build as UNSTABLE", results.getSkipCount(), unstableSkips)); 
         			 build.setResult(Result.UNSTABLE);
         		 }
-        	 } else if (thresholdMode == 2) {
+        	 } else if (thresholdMode == 2) { //percentage of tests
         		 float failedPercent = 100 * results.getFailCount() / (float) results.getTotalCount();
         		 float skipPercent = 100 * results.getSkipCount() / (float) results.getTotalCount();
-        		 if (failedPercent >= failedFails || skipPercent >= failedSkips) {
-        			 logger.println("Failed Tests exceeded threshold of " + failedFails + " or Skipped Tests exceeded threshold of " + failedSkips + ". Marking build as FAILURE.");
+        		 if (failedPercent > failedFails) {
+        			 logger.println(String.format("%f%% of tests failed, which exceeded threshold of %d%%. Marking build as FAILURE", failedPercent, failedFails)); 
         			 build.setResult(Result.FAILURE);
-        		 } else if (failedPercent >= unstableFails || skipPercent >= unstableSkips) {
-        			 logger.println("Failed Tests exceeded threshold of " + unstableFails + " or Skipped Tests exceeded threshold of " + unstableSkips + ". Marking build as UNSTABLE.");
+        		 } else if (skipPercent > failedSkips) {
+        			 logger.println(String.format("%f%% of tests were skipped, which exceeded threshold of %d%%. Marking build as FAILURE", skipPercent, failedSkips)); 
+        			 build.setResult(Result.FAILURE);
+        		 } else if (failedPercent > unstableFails) {
+        			 logger.println(String.format("%f%% of tests failed, which exceeded threshold of %d%%. Marking build as UNSTABLE", failedPercent, unstableFails)); 
+        			 build.setResult(Result.UNSTABLE);
+        		 } else if (skipPercent > unstableSkips) {
+        			 logger.println(String.format("%f%% of tests were skipped, which exceeded threshold of %d%%. Marking build as UNSTABLE", skipPercent, unstableSkips)); 
         			 build.setResult(Result.UNSTABLE);
         		 }
         	 } else {

--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -37,6 +37,8 @@ public class Publisher extends Recorder {
    public final boolean escapeTestDescp;
    //should exception messages be HTML escaped or not
    public final boolean escapeExceptionMsg;
+   //failed config mark build as failure
+   public final boolean failureOnFailedTestConfig;
    //should failed builds be included in graphs or not
    public final boolean showFailedBuilds;
    //number of skips that will trigger "Unstable"
@@ -55,11 +57,12 @@ public class Publisher extends Recorder {
 
    @DataBoundConstructor
    public Publisher(String reportFilenamePattern, boolean escapeTestDescp, boolean escapeExceptionMsg,
-                    boolean showFailedBuilds, int unstableSkips, int unstableFails, int failedSkips, int failedFails, boolean usePercentage) {
+                    boolean showFailedBuilds, boolean failureOnFailedTestConfig, int unstableSkips, int unstableFails, int failedSkips, int failedFails, boolean usePercentage) {
       this.reportFilenamePattern = reportFilenamePattern;
       this.escapeTestDescp = escapeTestDescp;
       this.escapeExceptionMsg = escapeExceptionMsg;
       this.showFailedBuilds = showFailedBuilds;
+      this.failureOnFailedTestConfig = failureOnFailedTestConfig;
       this.unstableSkips = unstableSkips;
       this.unstableFails = unstableFails;
       this.failedSkips = failedSkips;
@@ -143,6 +146,10 @@ public class Publisher extends Recorder {
       if (results.getTestList().size() > 0) {
          //create an individual report for all of the results and add it to the build
          build.addAction(new TestNGTestResultBuildAction(results));
+         if (failureOnFailedTestConfig && results.getFailedConfigCount() > 0) {
+            logger.println("Failed configuration methods found. Marking build as FAILURE.");
+            build.setResult(Result.FAILURE);
+         }
          if(usePercentage) {
             float failedPercent = 100 * results.getFailCount() / (float) results.getTotalCount();
             float skipPercent = 100 * results.getSkipCount() / (float) results.getTotalCount();

--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -44,7 +44,26 @@ public class Publisher extends Recorder {
    public final boolean unstableOnSkippedTests;
    //failed config mark build as failure
    public final boolean failureOnFailedTestConfig;
-   public final boolean useThresholds;
+   public final Threshold useThresholds;
+   public class Threshold{
+      public int unstableSkips;
+      public int unstableFails;
+      public int failedSkips;
+      public int failedFails;
+      public boolean usePercentage;
+
+      public void setUnstableSkips(int skips){this.unstableSkips=skips;}
+      public void setUnstableFails(int fails){this.unstableFails=fails;}
+      public void setFailedSkips(int skips){this.failedSkips=skips;}
+      public void setFailedFails(int fails){this.failedFails=fails;}
+      public void setUsePercentage(boolean percent){this.usePercentage=percent;}
+
+      public void getUnstableSkips(int skips){this.unstableSkips=skips;}
+      public void getUnstableFails(int fails){this.unstableFails=fails;}
+      public void getFailedSkips(int skips){this.failedSkips=skips;}
+      public void getFailedFails(int fails){this.failedFails=fails;}
+      public void getUsePercentage(boolean percent){this.usePercentage=percent;}
+   }
    //number of skips that will trigger "Unstable"
    public final int unstableSkips;
    //number of fails that will trigger "Unstable"
@@ -61,7 +80,7 @@ public class Publisher extends Recorder {
 
    @DataBoundConstructor
    public Publisher(String reportFilenamePattern, boolean escapeTestDescp, boolean escapeExceptionMsg,
-                    boolean showFailedBuilds, boolean unstableOnSkippedTests, boolean failureOnFailedTestConfig, boolean useThresholds,
+                    boolean showFailedBuilds, boolean unstableOnSkippedTests, boolean failureOnFailedTestConfig, Threshold useThresholds,
                     int unstableSkips, int unstableFails, int failedSkips, int failedFails, boolean usePercentage) {
       this.reportFilenamePattern = reportFilenamePattern;
       this.escapeTestDescp = escapeTestDescp;
@@ -174,7 +193,7 @@ public class Publisher extends Recorder {
                build.setResult(Result.UNSTABLE);
             } else if (results.getFailedConfigCount() > 0 || results.getFailCount() > 0) {
                logger.println("Failed Tests/Configs found. Marking build as UNSTABLE.");
-               build.setResult(Result.UNSTABLE);
+               build.setResult(Result.FAILURE);
             }
          }
       } else {

--- a/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
+++ b/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
@@ -18,20 +18,20 @@
       </f:entry>
       <f:section title="Mark build unstable thresholds">
       <f:entry title="${%Skipped}" field="unstableSkips">
-         <f:textbox default="0"/>
+         <f:textbox default="1"/>
       </f:entry>
       <f:entry title="${%Failed}" field="unstableFails">
-         <f:textbox default="0"/>
+         <f:textbox default="1"/>
       </f:entry>
       </f:section>
 
 
       <f:section title="Mark build failed thresholds">
       <f:entry title="${%Skipped}" field="failedSkips">
-         <f:textbox default="0"/>
+         <f:textbox default="1"/>
       </f:entry>
       <f:entry title="${%Failed}" field="failedFails">
-         <f:textbox default="0"/>
+         <f:textbox default="1"/>
       </f:entry>
       </f:section>
 

--- a/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
+++ b/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
@@ -35,12 +35,15 @@
       </f:entry>
       </f:section>
 
-      <f:entry field="usePercentage" title="Number/Percentage">
-         <select name="usePercentage">
-               <option value="false" selected="true">Number</option>
-               <option value="true">Percentage</option>
-         </select>
-      </f:entry>
+      <f:entry field="thresholdMode" title="${%Choose your threshold mode:}">
+			<f:radio name="thresholdMode"
+				value="1"
+				checked="${instance.thresholdMode==1 or h.defaultToTrue(instance.thresholdMode)}"/>
+			<label class="attach-previous">Number of tests</label>
+			<br/>
+			<f:radio name="thresholdMode" value="2" checked="${instance.thresholdMode==2}"/>
+			<label class="attach-previous">Percentage of tests</label>
+	  </f:entry>
 
    </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
+++ b/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
@@ -18,20 +18,20 @@
       </f:entry>
       <f:section title="Mark build unstable thresholds">
       <f:entry title="${%Skipped}" field="unstableSkips">
-         <f:textbox default="1"/>
+         <f:textbox default="0"/>
       </f:entry>
       <f:entry title="${%Failed}" field="unstableFails">
-         <f:textbox default="1"/>
+         <f:textbox default="0"/>
       </f:entry>
       </f:section>
 
 
       <f:section title="Mark build failed thresholds">
       <f:entry title="${%Skipped}" field="failedSkips">
-         <f:textbox default="1"/>
+         <f:textbox default="0"/>
       </f:entry>
       <f:entry title="${%Failed}" field="failedFails">
-         <f:textbox default="1"/>
+         <f:textbox default="0"/>
       </f:entry>
       </f:section>
 

--- a/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
+++ b/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
@@ -6,38 +6,46 @@
    <f:advanced>
       <f:entry title="Escape Test description string?" field="escapeTestDescp">
          <f:checkbox name="testng.escapeTestDescp" default="true" />
-	  </f:entry>
-	  <f:entry title="Escape exception messages?" field="escapeExceptionMsg">
+	   </f:entry>
+	   <f:entry title="Escape exception messages?" field="escapeExceptionMsg">
          <f:checkbox name="testng.escapeExceptionMsg" default="true" />
       </f:entry>
       <f:entry title="Show failed builds in trend graph?" field="showFailedBuilds">
          <f:checkbox name="testng.showFailedBuilds" default="false" />
       </f:entry>
+      <f:entry title="Mark build as unstable on skipped tests?" field="unstableOnSkippedTests">
+         <f:checkbox name="testng.unstableOnSkippedTests" default="false" />
+      </f:entry>
+      <f:entry title="Mark build as failure on failed configuration?" field="failureOnFailedTestConfig">
+         <f:checkbox name="testng.failureOnFailedTestConfig" default="false" />
+      </f:entry>
 
-      <f:section title="Mark build unstable thresholds">
-      <f:entry title="${%Skipped}" field="unstableSkips">
-         <f:textbox default="0"/>
-      </f:entry>
-      <f:entry title="${%Failed}" field="unstableFails">
-         <f:textbox default="0"/>
-      </f:entry>
-      </f:section>
+      <f:optionalBlock name="dynamic" title="Use thresholds" field="useThresholds">
+         <f:section title="Mark build unstable thresholds">
+         <f:entry title="${%Skipped}" field="unstableSkips">
+            <f:textbox default="0"/>
+         </f:entry>
+         <f:entry title="${%Failed}" field="unstableFails">
+            <f:textbox default="0"/>
+         </f:entry>
+         </f:section>
 
-      <f:section title="Mark build failed thresholds">
-      <f:entry title="${%Skipped}" field="failedSkips">
-         <f:textbox default="0"/>
-      </f:entry>
-      <f:entry title="${%Failed}" field="failedFails">
-         <f:textbox default="0"/>
-      </f:entry>
-      </f:section>
+         <f:section title="Mark build failed thresholds">
+         <f:entry title="${%Skipped}" field="failedSkips">
+            <f:textbox default="0"/>
+         </f:entry>
+         <f:entry title="${%Failed}" field="failedFails">
+            <f:textbox default="0"/>
+         </f:entry>
+         </f:section>
 
-      <f:entry field="usePercentage" title="Number/Percentage">
-         <select name="usePercentage">
-               <option value="false" selected="true">Number</option>
-               <option value="true">Percentage</option>
-         </select>
-      </f:entry>
+         <f:entry field="usePercentage" title="Number/Percentage">
+            <select name="usePercentage">
+                  <option value="false" selected="true">Number</option>
+                  <option value="true">Percentage</option>
+            </select>
+         </f:entry>
+      </f:optionalBlock>
 
    </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
+++ b/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
@@ -13,11 +13,31 @@
       <f:entry title="Show failed builds in trend graph?" field="showFailedBuilds">
          <f:checkbox name="testng.showFailedBuilds" default="false" />
       </f:entry>
-      <f:entry title="Mark build as unstable on skipped tests?" field="unstableOnSkippedTests">
-         <f:checkbox name="testng.unstableOnSkippedTests" default="false" />
+
+      <f:section title="Mark build unstable thresholds">
+      <f:entry title="${%Skipped}" field="unstableSkips">
+         <f:textbox default="0"/>
       </f:entry>
-      <f:entry title="Mark build as failure on failed configuration?" field="failureOnFailedTestConfig">
-         <f:checkbox name="testng.failureOnFailedTestConfig" default="false" />
+      <f:entry title="${%Failed}" field="unstableFails">
+         <f:textbox default="0"/>
       </f:entry>
+      </f:section>
+
+      <f:section title="Mark build failed thresholds">
+      <f:entry title="${%Skipped}" field="failedSkips">
+         <f:textbox default="0"/>
+      </f:entry>
+      <f:entry title="${%Failed}" field="failedFails">
+         <f:textbox default="0"/>
+      </f:entry>
+      </f:section>
+
+      <f:entry field="usePercentage" title="Number/Percentage">
+         <select name="usePercentage">
+               <option value="false" selected="true">Number</option>
+               <option value="true">Percentage</option>
+         </select>
+      </f:entry>
+
    </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
+++ b/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
@@ -18,7 +18,7 @@
       </f:entry>
       <f:section title="Mark build unstable thresholds">
       <f:entry title="${%Skipped}" field="unstableSkips">
-         <f:textbox default="0"/>
+         <f:textbox default="100"/>
       </f:entry>
       <f:entry title="${%Failed}" field="unstableFails">
          <f:textbox default="0"/>
@@ -28,20 +28,20 @@
 
       <f:section title="Mark build failed thresholds">
       <f:entry title="${%Skipped}" field="failedSkips">
-         <f:textbox default="0"/>
+         <f:textbox default="100"/>
       </f:entry>
       <f:entry title="${%Failed}" field="failedFails">
-         <f:textbox default="0"/>
+         <f:textbox default="100"/>
       </f:entry>
       </f:section>
 
       <f:entry field="thresholdMode" title="${%Choose your threshold mode:}">
 			<f:radio name="thresholdMode"
 				value="1"
-				checked="${instance.thresholdMode==1 or h.defaultToTrue(instance.thresholdMode)}"/>
+				checked="${instance.thresholdMode==1}"/>
 			<label class="attach-previous">Number of tests</label>
 			<br/>
-			<f:radio name="thresholdMode" value="2" checked="${instance.thresholdMode==2}"/>
+			<f:radio name="thresholdMode" value="2" checked="${instance.thresholdMode==2 or h.defaultToTrue(instance.thresholdMode)}"/>
 			<label class="attach-previous">Percentage of tests</label>
 	  </f:entry>
 

--- a/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
+++ b/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
@@ -20,7 +20,7 @@
          <f:checkbox name="testng.failureOnFailedTestConfig" default="false" />
       </f:entry>
 
-      <f:optionalBlock name="dynamic" title="Use thresholds" field="useThresholds">
+      <f:optionalBlock name="useThresholds" title="Use thresholds" field="useThresholds">
          <f:section title="Mark build unstable thresholds">
          <f:entry title="${%Skipped}" field="unstableSkips">
             <f:textbox default="0"/>

--- a/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
+++ b/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
@@ -13,7 +13,9 @@
       <f:entry title="Show failed builds in trend graph?" field="showFailedBuilds">
          <f:checkbox name="testng.showFailedBuilds" default="false" />
       </f:entry>
-
+      <f:entry title="Mark build as failure on failed configuration?" field="failureOnFailedTestConfig">
+         <f:checkbox name="testng.failureOnFailedTestConfig" default="false" />
+      </f:entry>
       <f:section title="Mark build unstable thresholds">
       <f:entry title="${%Skipped}" field="unstableSkips">
          <f:textbox default="0"/>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-failedFails.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-failedFails.html
@@ -1,4 +1,4 @@
 <div>
 <b>Fails - Failed Threshold</b>
-   <p>The maximum number of tests that can be failed before a job is marked as Failed</p>
+   <p>A build is marked FAILURE if the number/percentage of failed tests exceeds the specified threshold.</p>
 </div>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-failedFails.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-failedFails.html
@@ -1,0 +1,4 @@
+<div>
+<b>Fails - Failed Threshold</b>
+   <p>The maximum number of tests that can be failed before a job is marked as Failed</p>
+</div>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-failedSkips.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-failedSkips.html
@@ -1,0 +1,4 @@
+<div>
+   <b>Skips - Failed Threshold</b>
+   <p>The maximum number of tests that can be skipped before a job is marked as Failed</p>
+</div>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-failedSkips.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-failedSkips.html
@@ -1,4 +1,4 @@
 <div>
    <b>Skips - Failed Threshold</b>
-   <p>The maximum number of tests that can be skipped before a job is marked as Failed</p>
+   <p>A build is marked FAILURE if the number/percentage of skipped tests exceeds the specified threshold.</p>
 </div>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-failureOnFailedTestConfig.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-failureOnFailedTestConfig.html
@@ -1,5 +1,6 @@
 <div>
     <b>Mark as failure on Failed Test Configuration Methods</b>
     <p>Allows for a distinction between failing tests and failing configuration methods.
-        Failing tests can be seen as an unstable build whereas failing configuration methods are a failed build</p>
+        Failing tests can be seen as an unstable build whereas failing configuration methods are a failed build.
+        This will trump any settings in Thresholds section.</p>
 </div>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-unstableFails.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-unstableFails.html
@@ -1,0 +1,4 @@
+<div>
+<b>Fails - Unstable Threshold</b>
+   <p>The maximum number of tests that can be failed before a job is marked as Unstable</p>
+</div>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-unstableFails.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-unstableFails.html
@@ -1,4 +1,4 @@
 <div>
 <b>Fails - Unstable Threshold</b>
-   <p>The maximum number of tests that can be failed before a job is marked as Unstable</p>
+   <p>A build is marked UNSTABLE if the number/percentage of failed tests exceeds the specified threshold.</p>
 </div>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-unstableSkips.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-unstableSkips.html
@@ -1,4 +1,4 @@
 <div>
    <b>Skips - Unstable Threshold</b>
-   <p>The maximum number of tests that can be skipped before a job is marked as Unstable</p>
+   <p>A build is marked UNSTABLE if the number/percentage of skipped tests exceeds the specified threshold.</p>
 </div>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-unstableSkips.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-unstableSkips.html
@@ -1,0 +1,4 @@
+<div>
+   <b>Skips - Unstable Threshold</b>
+   <p>The maximum number of tests that can be skipped before a job is marked as Unstable</p>
+</div>

--- a/src/test/java/hudson/plugins/testng/Constants.java
+++ b/src/test/java/hudson/plugins/testng/Constants.java
@@ -52,6 +52,11 @@ public class Constants {
      * Contains 1 passed and 1 skipped test
      */
     public static final String TESTNG_SKIPPED_TEST = "testng-skipped-tests.xml";
+    
+    /**
+     * Contains 1 passed and 1 failed test
+     */
+    public static final String TESTNG_FAILED_TEST = "testng-failed-tests.xml";
     /**
      * Contains 1 failed config and 1 skipped test
      */

--- a/src/test/java/hudson/plugins/testng/PublisherCtor.java
+++ b/src/test/java/hudson/plugins/testng/PublisherCtor.java
@@ -12,14 +12,14 @@ public class PublisherCtor {
     private boolean escapeTestDescp = true;
     private boolean showFailedBuilds = false;
     private boolean failureOnFailedTestConfig = false;
-    private int unstableSkips = 1;
-    private int unstableFails = 1;
-    private int failedSkips = 1;
-    private int failedFails = 1;
+    private int unstableSkips = 0;
+    private int unstableFails = 0;
+    private int failedSkips = 0;
+    private int failedFails = 0;
     private int thresholdMode = 1; //default mode is 1 (number of tests)
 
     public Publisher getNewPublisher() {
-        return new Publisher(reportFilenamePattern, escapeTestDescp, failureOnFailedTestConfig, escapeExceptionMsg, showFailedBuilds,
+        return new Publisher(reportFilenamePattern, escapeTestDescp, escapeExceptionMsg, showFailedBuilds, failureOnFailedTestConfig, 
                 unstableSkips, unstableFails, failedSkips, failedFails, thresholdMode);
     }
 

--- a/src/test/java/hudson/plugins/testng/PublisherCtor.java
+++ b/src/test/java/hudson/plugins/testng/PublisherCtor.java
@@ -16,11 +16,11 @@ public class PublisherCtor {
     private int unstableFails = 1;
     private int failedSkips = 1;
     private int failedFails = 1;
-    private boolean usePercentage = false;
+    private int thresholdMode = 1; //default mode is 1 (number of tests)
 
     public Publisher getNewPublisher() {
         return new Publisher(reportFilenamePattern, escapeTestDescp, failureOnFailedTestConfig, escapeExceptionMsg, showFailedBuilds,
-                unstableSkips, unstableFails, failedSkips, failedFails, usePercentage);
+                unstableSkips, unstableFails, failedSkips, failedFails, thresholdMode);
     }
 
     public PublisherCtor setReportFilenamePattern(String reportFilenamePattern) {
@@ -68,8 +68,8 @@ public class PublisherCtor {
         return this;
     }
 
-    public PublisherCtor setUsePercentage(boolean usePercentage) {
-        this.usePercentage = usePercentage;
+    public PublisherCtor setThresholdType(int thresholdMode) {
+        this.thresholdMode = thresholdMode;
         return this;
     }
 }

--- a/src/test/java/hudson/plugins/testng/PublisherCtor.java
+++ b/src/test/java/hudson/plugins/testng/PublisherCtor.java
@@ -11,6 +11,9 @@ public class PublisherCtor {
     private boolean escapeExceptionMsg = true;
     private boolean escapeTestDescp = true;
     private boolean showFailedBuilds = false;
+    private boolean unstableOnSkippedTests = false;
+    private boolean failureOnFailedTestConfig = false;
+    private boolean useThresholds = false;
     private int unstableSkips = 0;
     private int unstableFails = 0;
     private int failedSkips = 0;
@@ -19,6 +22,7 @@ public class PublisherCtor {
 
     public Publisher getNewPublisher() {
         return new Publisher(reportFilenamePattern, escapeTestDescp, escapeExceptionMsg, showFailedBuilds,
+                unstableOnSkippedTests, failureOnFailedTestConfig, useThresholds,
                 unstableSkips, unstableFails, failedSkips, failedFails, usePercentage);
     }
 
@@ -42,6 +46,21 @@ public class PublisherCtor {
         return this;
     }
 
+    public PublisherCtor setUnstableOnSkippedTests(boolean unstableOnSkippedTests) {
+        this.unstableOnSkippedTests = unstableOnSkippedTests;
+        return this;
+    }
+
+    public PublisherCtor setFailureOnFailedTestConfig(boolean failureOnFailedTestConfig) {
+        this.failureOnFailedTestConfig = failureOnFailedTestConfig;
+        return this;
+    }
+
+    public PublisherCtor setUseThresholds(boolean useThresholds) {
+        this.useThresholds = useThresholds;
+        return this;
+    }
+
     public PublisherCtor setUnstableSkips(int unstableSkips) {
         this.unstableSkips = unstableSkips;
         return this;
@@ -59,6 +78,11 @@ public class PublisherCtor {
 
     public PublisherCtor setFailedFails(int failedFails) {
         this.failedFails = failedFails;
+        return this;
+    }
+
+    public PublisherCtor setUsePercentage(boolean usePercentage) {
+        this.usePercentage = usePercentage;
         return this;
     }
 }

--- a/src/test/java/hudson/plugins/testng/PublisherCtor.java
+++ b/src/test/java/hudson/plugins/testng/PublisherCtor.java
@@ -11,12 +11,15 @@ public class PublisherCtor {
     private boolean escapeExceptionMsg = true;
     private boolean escapeTestDescp = true;
     private boolean showFailedBuilds = false;
-    private boolean unstableOnSkippedTests = false;
-    private boolean failureOnFailedTestConfig = false;
+    private int unstableSkips = 0;
+    private int unstableFails = 0;
+    private int failedSkips = 0;
+    private int failedFails = 0;
+    private boolean usePercentage = false;
 
     public Publisher getNewPublisher() {
         return new Publisher(reportFilenamePattern, escapeTestDescp, escapeExceptionMsg, showFailedBuilds,
-                unstableOnSkippedTests, failureOnFailedTestConfig);
+                unstableSkips, unstableFails, failedSkips, failedFails, usePercentage);
     }
 
     public PublisherCtor setReportFilenamePattern(String reportFilenamePattern) {
@@ -39,13 +42,23 @@ public class PublisherCtor {
         return this;
     }
 
-    public PublisherCtor setUnstableOnSkippedTests(boolean unstableOnSkippedTests) {
-        this.unstableOnSkippedTests = unstableOnSkippedTests;
+    public PublisherCtor setUnstableSkips(int unstableSkips) {
+        this.unstableSkips = unstableSkips;
         return this;
     }
 
-    public PublisherCtor setFailureOnFailedTestConfig(boolean failureOnFailedTestConfig) {
-        this.failureOnFailedTestConfig = failureOnFailedTestConfig;
+    public PublisherCtor setUnstableFails(int unstableFails) {
+        this.unstableFails = unstableFails;
+        return this;
+    }
+
+    public PublisherCtor setFailedSkips(int failedSkips) {
+        this.failedSkips = failedSkips;
+        return this;
+    }
+
+    public PublisherCtor setFailedFails(int failedFails) {
+        this.failedFails = failedFails;
         return this;
     }
 }

--- a/src/test/java/hudson/plugins/testng/PublisherCtor.java
+++ b/src/test/java/hudson/plugins/testng/PublisherCtor.java
@@ -12,11 +12,11 @@ public class PublisherCtor {
     private boolean escapeTestDescp = true;
     private boolean showFailedBuilds = false;
     private boolean failureOnFailedTestConfig = false;
-    private int unstableSkips = 0;
+    private int unstableSkips = 100;
     private int unstableFails = 0;
-    private int failedSkips = 0;
-    private int failedFails = 0;
-    private int thresholdMode = 1; //default mode is 1 (number of tests)
+    private int failedSkips = 100;
+    private int failedFails = 100;
+    private int thresholdMode = 2; //default mode is 2 (percentage of tests)
 
     public Publisher getNewPublisher() {
         return new Publisher(reportFilenamePattern, escapeTestDescp, escapeExceptionMsg, showFailedBuilds, failureOnFailedTestConfig, 

--- a/src/test/java/hudson/plugins/testng/PublisherCtor.java
+++ b/src/test/java/hudson/plugins/testng/PublisherCtor.java
@@ -11,6 +11,7 @@ public class PublisherCtor {
     private boolean escapeExceptionMsg = true;
     private boolean escapeTestDescp = true;
     private boolean showFailedBuilds = false;
+    private boolean failureOnFailedTestConfig = false;
     private int unstableSkips = 0;
     private int unstableFails = 0;
     private int failedSkips = 0;
@@ -18,7 +19,7 @@ public class PublisherCtor {
     private boolean usePercentage = false;
 
     public Publisher getNewPublisher() {
-        return new Publisher(reportFilenamePattern, escapeTestDescp, escapeExceptionMsg, showFailedBuilds,
+        return new Publisher(reportFilenamePattern, escapeTestDescp, failureOnFailedTestConfig, escapeExceptionMsg, showFailedBuilds,
                 unstableSkips, unstableFails, failedSkips, failedFails, usePercentage);
     }
 
@@ -42,7 +43,12 @@ public class PublisherCtor {
         return this;
     }
 
-    public PublisherCtor setUnstableSkips(int unstableSkips) {
+    public PublisherCtor setFailureOnFailedTestConfig(boolean failureOnFailedTestConfig) {
+       this.failureOnFailedTestConfig = failureOnFailedTestConfig;
+       return this;
+    }
+
+   public PublisherCtor setUnstableSkips(int unstableSkips) {
         this.unstableSkips = unstableSkips;
         return this;
     }

--- a/src/test/java/hudson/plugins/testng/PublisherCtor.java
+++ b/src/test/java/hudson/plugins/testng/PublisherCtor.java
@@ -12,10 +12,10 @@ public class PublisherCtor {
     private boolean escapeTestDescp = true;
     private boolean showFailedBuilds = false;
     private boolean failureOnFailedTestConfig = false;
-    private int unstableSkips = 0;
-    private int unstableFails = 0;
-    private int failedSkips = 0;
-    private int failedFails = 0;
+    private int unstableSkips = 1;
+    private int unstableFails = 1;
+    private int failedSkips = 1;
+    private int failedFails = 1;
     private boolean usePercentage = false;
 
     public Publisher getNewPublisher() {

--- a/src/test/java/hudson/plugins/testng/PublisherTest.java
+++ b/src/test/java/hudson/plugins/testng/PublisherTest.java
@@ -91,7 +91,7 @@ public class PublisherTest extends HudsonTestCase {
     @Test
     public void testRoundTrip() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
-        Publisher before = new Publisher("", false, false, true, 0, 0, 0, 0, false);
+        Publisher before = new Publisher("", false, false, true, false, 0, 0, 0, 0, false);
         p.getPublishersList().add(before);
 
         submit(createWebClient().getPage(p,"configure").getFormByName("config"));

--- a/src/test/java/hudson/plugins/testng/PublisherTest.java
+++ b/src/test/java/hudson/plugins/testng/PublisherTest.java
@@ -91,7 +91,7 @@ public class PublisherTest extends HudsonTestCase {
     @Test
     public void testRoundTrip() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
-        Publisher before = new Publisher("", false, false, true, 0, 0, 0, 0, false);
+        Publisher before = new Publisher("", false, false, true, true, true, false, 0, 0, 0, 0, false);
         p.getPublishersList().add(before);
 
         submit(createWebClient().getPage(p,"configure").getFormByName("config"));

--- a/src/test/java/hudson/plugins/testng/PublisherTest.java
+++ b/src/test/java/hudson/plugins/testng/PublisherTest.java
@@ -91,7 +91,7 @@ public class PublisherTest extends HudsonTestCase {
     @Test
     public void testRoundTrip() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
-        Publisher before = new Publisher("", false, false, true, true, true);
+        Publisher before = new Publisher("", false, false, true, 0, 0, 0, 0, false);
         p.getPublishersList().add(before);
 
         submit(createWebClient().getPage(p,"configure").getFormByName("config"));

--- a/src/test/java/hudson/plugins/testng/PublisherTest.java
+++ b/src/test/java/hudson/plugins/testng/PublisherTest.java
@@ -13,6 +13,7 @@ import hudson.model.Result;
 import junit.framework.Assert;
 import org.junit.Test;
 import org.jvnet.hudson.test.HudsonTestCase;
+import hudson.plugins.testng.PublisherCtor;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -91,7 +92,7 @@ public class PublisherTest extends HudsonTestCase {
     @Test
     public void testRoundTrip() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
-        Publisher before = new Publisher("", false, false, true, false, 0, 0, 0, 0, false);
+        Publisher before = new Publisher("", false, false, true, false, 0, 0, 0, 0, 1);
         p.getPublishersList().add(before);
 
         submit(createWebClient().getPage(p,"configure").getFormByName("config"));

--- a/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
+++ b/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
@@ -235,7 +235,7 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
     public void test_skipped_tests_enabled() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-                .setUnstableSkips(0);
+                .setUnstableOnSkippedTests(true);
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action
@@ -259,7 +259,7 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
     public void test_skipped_tests_enabled_failedbuild() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-                .setUnstableSkips(0);
+                .setUnstableOnSkippedTests(true);
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action
@@ -305,7 +305,7 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
     public void test_failed_config_enabled_failedbuild() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-                .setFailedFails(0);
+                .setFailureOnFailedTestConfig(true);
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action

--- a/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
+++ b/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
@@ -207,19 +207,20 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
         assertStringContains(element.getTextContent(), "526 tests");
     }
 
-    //unstableOnSkippedTests set to false
     @Test
-    public void test_skipped_tests_default_setting() throws Exception {
+    public void test_failed_config_default_setting() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml");
+        publisherCtor.setFailedSkips(10); //these prevent the skip that results from config failure from determining result
+        publisherCtor.setUnstableSkips(10);
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action
 
         p.getBuildersList().add(new TestBuilder() {
             public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
-                BuildListener listener) throws InterruptedException, IOException {
-                String contents = CommonUtil.getContents(Constants.TESTNG_SKIPPED_TEST);
+                                   BuildListener listener) throws InterruptedException, IOException {
+                String contents = CommonUtil.getContents(Constants.TESTNG_FAILED_TEST_CONFIG);
                 build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
                 return true;
             }
@@ -230,82 +231,13 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
         Assert.assertSame(Result.SUCCESS, build.getResult());
     }
 
-    //unstableOnSkippedTests set to true
-    @Test
-    public void test_skipped_tests_enabled() throws Exception {
-        FreeStyleProject p = createFreeStyleProject();
-        PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-                .setUnstableSkips(0);
-        Publisher publisher = publisherCtor.getNewPublisher();
-        p.getPublishersList().add(publisher);
-        p.onCreatedFromScratch(); //to setup project action
-
-        p.getBuildersList().add(new TestBuilder() {
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
-                BuildListener listener) throws InterruptedException, IOException {
-                String contents = CommonUtil.getContents(Constants.TESTNG_SKIPPED_TEST);
-                build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
-                return true;
-            }
-        });
-
-        //run build
-        FreeStyleBuild build = p.scheduleBuild2(0).get();
-        Assert.assertSame(Result.UNSTABLE, build.getResult());
-    }
-
-    //unstableOnSkippedTests set to true. Has no effect as build is already marked failed
-    @Test
-    public void test_skipped_tests_enabled_failedbuild() throws Exception {
-        FreeStyleProject p = createFreeStyleProject();
-        PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-                .setUnstableSkips(0);
-        Publisher publisher = publisherCtor.getNewPublisher();
-        p.getPublishersList().add(publisher);
-        p.onCreatedFromScratch(); //to setup project action
-
-        p.getBuildersList().add(new TestBuilder() {
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
-                BuildListener listener) throws InterruptedException, IOException {
-                String contents = CommonUtil.getContents(Constants.TESTNG_SKIPPED_TEST);
-                build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
-                build.setResult(Result.FAILURE);
-                return true;
-            }
-        });
-
-        //run build
-        FreeStyleBuild build = p.scheduleBuild2(0).get();
-        Assert.assertSame(Result.FAILURE, build.getResult());
-    }
-
-    @Test
-    public void test_failed_config_default_setting() throws Exception {
-        FreeStyleProject p = createFreeStyleProject();
-        PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml");
-        Publisher publisher = publisherCtor.getNewPublisher();
-        p.getPublishersList().add(publisher);
-        p.onCreatedFromScratch(); //to setup project action
-
-        p.getBuildersList().add(new TestBuilder() {
-            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
-                                   BuildListener listener) throws InterruptedException, IOException {
-                String contents = CommonUtil.getContents(Constants.TESTNG_FAILED_TEST_CONFIG);
-                build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
-                return true;
-            }
-        });
-
-        //run build
-        FreeStyleBuild build = p.scheduleBuild2(0).get();
-        Assert.assertSame(Result.UNSTABLE, build.getResult());
-    }
-
     @Test
     public void test_failed_config_enabled_failedbuild() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
                 .setFailureOnFailedTestConfig(true);
+        publisherCtor.setFailedSkips(10); //these prevent the skip that results from config failure from determining result
+        publisherCtor.setUnstableSkips(10);
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action
@@ -323,7 +255,28 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
         FreeStyleBuild build = p.scheduleBuild2(0).get();
         Assert.assertSame(Result.FAILURE, build.getResult());
     }
+    @Test
+    public void test_threshold_for_skips_default() throws Exception {
+       FreeStyleProject p = createFreeStyleProject();
+       PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml");
+       Publisher publisher = publisherCtor.getNewPublisher();
+       p.getPublishersList().add(publisher);
+       p.onCreatedFromScratch(); //to setup project action
 
+       p.getBuildersList().add(new TestBuilder() {
+          public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                                 BuildListener listener) throws InterruptedException, IOException {
+             String contents = CommonUtil.getContents(Constants.TESTNG_SKIPPED_TEST);
+             build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
+             return true;
+          }
+       });
+
+       //run build
+       FreeStyleBuild build = p.scheduleBuild2(0).get();
+       Assert.assertSame(Result.FAILURE, build.getResult());
+    }
+    
    @Test
    public void test_threshold_for_skips_failure() throws Exception {
       FreeStyleProject p = createFreeStyleProject();
@@ -369,4 +322,72 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
       FreeStyleBuild build = p.scheduleBuild2(0).get();
       Assert.assertSame(Result.UNSTABLE, build.getResult());
    }
+   
+   @Test
+   public void test_threshold_for_fails_default() throws Exception {
+      FreeStyleProject p = createFreeStyleProject();
+      PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml");
+      Publisher publisher = publisherCtor.getNewPublisher();
+      p.getPublishersList().add(publisher);
+      p.onCreatedFromScratch(); //to setup project action
+
+      p.getBuildersList().add(new TestBuilder() {
+         public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                                BuildListener listener) throws InterruptedException, IOException {
+            String contents = CommonUtil.getContents(Constants.TESTNG_SKIPPED_TEST);
+            build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
+            return true;
+         }
+      });
+
+      //run build
+      FreeStyleBuild build = p.scheduleBuild2(0).get();
+      Assert.assertSame(Result.FAILURE, build.getResult());
+   }
+   
+  @Test
+  public void test_threshold_for_fails_failure() throws Exception {
+     FreeStyleProject p = createFreeStyleProject();
+     PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
+           .setFailedFails(2).setUnstableFails(2);
+     Publisher publisher = publisherCtor.getNewPublisher();
+     p.getPublishersList().add(publisher);
+     p.onCreatedFromScratch(); //to setup project action
+
+     p.getBuildersList().add(new TestBuilder() {
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                               BuildListener listener) throws InterruptedException, IOException {
+           String contents = CommonUtil.getContents(Constants.TESTNG_FAILED_TEST);
+           build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
+           return true;
+        }
+     });
+
+     //run build
+     FreeStyleBuild build = p.scheduleBuild2(0).get();
+     Assert.assertSame(Result.SUCCESS, build.getResult());
+  }
+
+  @Test
+  public void test_threshold_for_fails_unstable() throws Exception {
+     FreeStyleProject p = createFreeStyleProject();
+     PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
+           .setFailedFails(2);
+     Publisher publisher = publisherCtor.getNewPublisher();
+     p.getPublishersList().add(publisher);
+     p.onCreatedFromScratch(); //to setup project action
+
+     p.getBuildersList().add(new TestBuilder() {
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                               BuildListener listener) throws InterruptedException, IOException {
+           String contents = CommonUtil.getContents(Constants.TESTNG_FAILED_TEST);
+           build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
+           return true;
+        }
+     });
+
+     //run build
+     FreeStyleBuild build = p.scheduleBuild2(0).get();
+     Assert.assertSame(Result.UNSTABLE, build.getResult());
+  }
 }

--- a/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
+++ b/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
@@ -235,7 +235,7 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
     public void test_skipped_tests_enabled() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-                .setUnstableOnSkippedTests(true);
+                .setUnstableSkips(0);
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action
@@ -259,7 +259,7 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
     public void test_skipped_tests_enabled_failedbuild() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-                .setUnstableOnSkippedTests(true);
+                .setUnstableSkips(0);
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action
@@ -305,7 +305,7 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
     public void test_failed_config_enabled_failedbuild() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-                .setFailureOnFailedTestConfig(true);
+                .setFailedFails(0);
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action

--- a/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
+++ b/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
@@ -211,8 +211,8 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
     public void test_failed_config_default_setting() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml");
-        publisherCtor.setFailedSkips(10); //these prevent the skip that results from config failure from determining result
-        publisherCtor.setUnstableSkips(10);
+        publisherCtor.setFailedSkips(100); //these prevent the skip that results from config failure from determining result
+        publisherCtor.setUnstableSkips(100);
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action
@@ -274,14 +274,14 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
 
        //run build
        FreeStyleBuild build = p.scheduleBuild2(0).get();
-       Assert.assertSame(Result.FAILURE, build.getResult());
+       Assert.assertSame(Result.SUCCESS, build.getResult());
     }
     
    @Test
    public void test_threshold_for_skips_failure() throws Exception {
       FreeStyleProject p = createFreeStyleProject();
       PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-            .setFailedSkips(2).setUnstableSkips(2);
+            .setFailedSkips(100).setUnstableSkips(100);
       Publisher publisher = publisherCtor.getNewPublisher();
       p.getPublishersList().add(publisher);
       p.onCreatedFromScratch(); //to setup project action
@@ -304,7 +304,7 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
    public void test_threshold_for_skips_unstable() throws Exception {
       FreeStyleProject p = createFreeStyleProject();
       PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-            .setFailedSkips(2);
+            .setUnstableSkips(0).setFailedSkips(100);
       Publisher publisher = publisherCtor.getNewPublisher();
       p.getPublishersList().add(publisher);
       p.onCreatedFromScratch(); //to setup project action
@@ -334,7 +334,7 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
       p.getBuildersList().add(new TestBuilder() {
          public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
                                 BuildListener listener) throws InterruptedException, IOException {
-            String contents = CommonUtil.getContents(Constants.TESTNG_SKIPPED_TEST);
+            String contents = CommonUtil.getContents(Constants.TESTNG_FAILED_TEST);
             build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
             return true;
          }
@@ -342,14 +342,14 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
 
       //run build
       FreeStyleBuild build = p.scheduleBuild2(0).get();
-      Assert.assertSame(Result.FAILURE, build.getResult());
+      Assert.assertSame(Result.UNSTABLE, build.getResult());
    }
    
   @Test
   public void test_threshold_for_fails_failure() throws Exception {
      FreeStyleProject p = createFreeStyleProject();
      PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-           .setFailedFails(2).setUnstableFails(2);
+           .setFailedFails(100).setUnstableFails(100);
      Publisher publisher = publisherCtor.getNewPublisher();
      p.getPublishersList().add(publisher);
      p.onCreatedFromScratch(); //to setup project action
@@ -372,7 +372,7 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
   public void test_threshold_for_fails_unstable() throws Exception {
      FreeStyleProject p = createFreeStyleProject();
      PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-           .setFailedFails(2);
+           .setFailedFails(100);
      Publisher publisher = publisherCtor.getNewPublisher();
      p.getPublishersList().add(publisher);
      p.onCreatedFromScratch(); //to setup project action

--- a/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
+++ b/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
@@ -305,7 +305,7 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
     public void test_failed_config_enabled_failedbuild() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
-                .setFailedFails(0);
+                .setFailureOnFailedTestConfig(true);
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action

--- a/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
+++ b/src/test/java/hudson/plugins/testng/TestNGTestResultBuildActionTest.java
@@ -324,5 +324,49 @@ public class TestNGTestResultBuildActionTest extends HudsonTestCase {
         Assert.assertSame(Result.FAILURE, build.getResult());
     }
 
+   @Test
+   public void test_threshold_for_skips_failure() throws Exception {
+      FreeStyleProject p = createFreeStyleProject();
+      PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
+            .setFailedSkips(2).setUnstableSkips(2);
+      Publisher publisher = publisherCtor.getNewPublisher();
+      p.getPublishersList().add(publisher);
+      p.onCreatedFromScratch(); //to setup project action
 
+      p.getBuildersList().add(new TestBuilder() {
+         public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                                BuildListener listener) throws InterruptedException, IOException {
+            String contents = CommonUtil.getContents(Constants.TESTNG_SKIPPED_TEST);
+            build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
+            return true;
+         }
+      });
+
+      //run build
+      FreeStyleBuild build = p.scheduleBuild2(0).get();
+      Assert.assertSame(Result.SUCCESS, build.getResult());
+   }
+
+   @Test
+   public void test_threshold_for_skips_unstable() throws Exception {
+      FreeStyleProject p = createFreeStyleProject();
+      PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
+            .setFailedSkips(2);
+      Publisher publisher = publisherCtor.getNewPublisher();
+      p.getPublishersList().add(publisher);
+      p.onCreatedFromScratch(); //to setup project action
+
+      p.getBuildersList().add(new TestBuilder() {
+         public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                                BuildListener listener) throws InterruptedException, IOException {
+            String contents = CommonUtil.getContents(Constants.TESTNG_SKIPPED_TEST);
+            build.getWorkspace().child("testng.xml").write(contents,"UTF-8");
+            return true;
+         }
+      });
+
+      //run build
+      FreeStyleBuild build = p.scheduleBuild2(0).get();
+      Assert.assertSame(Result.UNSTABLE, build.getResult());
+   }
 }

--- a/src/test/java/hudson/plugins/testng/results/MethodResultTest.java
+++ b/src/test/java/hudson/plugins/testng/results/MethodResultTest.java
@@ -34,6 +34,7 @@ public class MethodResultTest extends HudsonTestCase {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
                         .setEscapeTestDescp(false).setEscapeExceptionMsg(true);
+        publisherCtor.setFailedFails(10); //this prevents default fail thresholds from determining result
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action

--- a/src/test/java/hudson/plugins/testng/results/MethodResultTest.java
+++ b/src/test/java/hudson/plugins/testng/results/MethodResultTest.java
@@ -34,7 +34,7 @@ public class MethodResultTest extends HudsonTestCase {
         FreeStyleProject p = createFreeStyleProject();
         PublisherCtor publisherCtor = new PublisherCtor().setReportFilenamePattern("testng.xml")
                         .setEscapeTestDescp(false).setEscapeExceptionMsg(true);
-        publisherCtor.setFailedFails(10); //this prevents default fail thresholds from determining result
+        publisherCtor.setFailedFails(100); //this prevents default fail thresholds from determining result
         Publisher publisher = publisherCtor.getNewPublisher();
         p.getPublishersList().add(publisher);
         p.onCreatedFromScratch(); //to setup project action

--- a/src/test/resources/testng-failed-tests.xml
+++ b/src/test/resources/testng-failed-tests.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testng-results skipped="0" failed="0" total="121" passed="121">
+  <reporter-output>
+  </reporter-output>
+  <suite name="Skipped Tests suite" duration-ms="23913" started-at="2012-01-23T10:51:27Z" finished-at="2012-01-23T10:51:51Z">
+    <groups>
+    </groups>
+    <test name="Skipped Tests test" duration-ms="23913" started-at="2012-01-23T10:51:27Z" finished-at="2012-01-23T10:51:51Z">
+      <class name="com.fakepkg.test.MyFakeTest">
+        <test-method status="FAIL" signature="methodSignature()[pri:0, instance:my.package.MyFakeTest@1d6747b]" name="testShouldFAIL" duration-ms="11" started-at="2012-01-23T10:51:51Z" finished-at="2012-01-23T10:51:51Z" />
+        <test-method status="PASS" signature="methodSignature()[pri:0, instance:my.package.MyFakeTest@1d6747b]" name="testShouldPass" duration-ms="11" started-at="2012-01-23T10:51:51Z" finished-at="2012-01-23T10:51:51Z" />
+      </class>
+    </test>
+  </suite>
+</testng-results>


### PR DESCRIPTION
Myself and a team of co-workers from Interactive Intelligence made some updates to the testNG plugin for a company Hackathon. This is the first of a few PR's that we'll be posting incrementally. 

These additions do not change the default behavior of the plugin (just mark unstable on test failures). However, they allow the user to configure a percentage or number of test failures/skips to mark the build as FAILURE/UNSTABLE.

