### PR TITLE
add support for testng retries

### DIFF
--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 
 import hudson.EnvVars;
 import hudson.Extension;
@@ -18,6 +20,7 @@ import hudson.model.Action;
 import hudson.model.BuildListener;
 import hudson.model.Result;
 import hudson.plugins.testng.results.TestNGResult;
+import hudson.plugins.testng.results.MethodResult;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Recorder;
@@ -43,20 +46,23 @@ public class Publisher extends Recorder {
    public final boolean unstableOnSkippedTests;
    //failed config mark build as failure
    public final boolean failureOnFailedTestConfig;
-
+   //ignore test failure if one passed
+   public final boolean ignoreTestFailureIfTestPassesOnce;
 
    @Extension
    public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
    @DataBoundConstructor
    public Publisher(String reportFilenamePattern, boolean escapeTestDescp, boolean escapeExceptionMsg,
-                    boolean showFailedBuilds, boolean unstableOnSkippedTests, boolean failureOnFailedTestConfig) {
+                    boolean showFailedBuilds, boolean unstableOnSkippedTests, boolean failureOnFailedTestConfig, 
+                    boolean ignoreTestFailureIfTestPassesOnce) {
       this.reportFilenamePattern = reportFilenamePattern;
       this.escapeTestDescp = escapeTestDescp;
       this.escapeExceptionMsg = escapeExceptionMsg;
       this.showFailedBuilds = showFailedBuilds;
       this.unstableOnSkippedTests = unstableOnSkippedTests;
       this.failureOnFailedTestConfig = failureOnFailedTestConfig;
+      this.ignoreTestFailureIfTestPassesOnce = ignoreTestFailureIfTestPassesOnce;
    }
 
    public BuildStepMonitor getRequiredMonitorService() {
@@ -141,10 +147,22 @@ public class Publisher extends Recorder {
          } else if (unstableOnSkippedTests && (results.getSkippedConfigCount() > 0 || results.getSkipCount() > 0)) {
             logger.println("Skipped Tests/Configs found. Marking build as UNSTABLE.");
             build.setResult(Result.UNSTABLE);
-         } else if (results.getFailedConfigCount() > 0 || results.getFailCount() > 0) {
-            logger.println("Failed Tests/Configs found. Marking build as UNSTABLE.");
+         } else if (results.getFailedConfigCount() > 0) {
+            logger.println("Failed Configs found. Marking build as UNSTABLE.");
             build.setResult(Result.UNSTABLE);
-         }
+         } else if(results.getFailCount() > 0) {
+            if(ignoreTestFailureIfTestPassesOnce ) {
+                if(countFailIgnoreTestPassesOnce(results) > 0) {
+                    logger.println("Failed Tests found. Marking build as UNSTABLE.");
+                    build.setResult(Result.UNSTABLE);
+                } else {
+                    logger.println("Failed Tests found, but were ignored because the test passed once.");
+                }
+            } else {
+                logger.println("Failed Tests found. Marking build as UNSTABLE.");
+                build.setResult(Result.UNSTABLE);
+             }
+         } 
       } else {
          logger.println("Found matching files but did not find any TestNG results.");
          return true;
@@ -152,6 +170,22 @@ public class Publisher extends Recorder {
       logger.println("TestNG Reports Processing: FINISH");
       return true;
    }
+
+    int countFailIgnoreTestPassesOnce(TestNGResult results) {
+        int count = 0;
+        Set<String> passed = new HashSet<String>();
+        for (MethodResult test : results.getPassedTests()) {
+            passed.add(test.getName());
+        }
+
+        for (MethodResult test : results.getFailedTests()) {
+            if(!passed.contains(test.getName())) {
+                ++count;
+            }
+        }
+
+        return count;
+    }
 
    /**
     * look for testng reports based in the configured parameter includes.

--- a/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
+++ b/src/main/resources/hudson/plugins/testng/Publisher/config.jelly
@@ -19,5 +19,8 @@
       <f:entry title="Mark build as failure on failed configuration?" field="failureOnFailedTestConfig">
          <f:checkbox name="testng.failureOnFailedTestConfig" default="false" />
       </f:entry>
+      <f:entry title="Ignore test failure if test passes once?" field="ignoreTestFailureIfTestPassesOnce">
+         <f:checkbox name="testng.ignoreTestFailureIfTestPassesOnce" default="false" />
+      </f:entry>
    </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/testng/Publisher/help-ignoreTestFailureIfTestPassesOnce.html
+++ b/src/main/resources/hudson/plugins/testng/Publisher/help-ignoreTestFailureIfTestPassesOnce.html
@@ -1,0 +1,5 @@
+<div>
+    <b>Ignore Test Failures if the Test passes at least once</b>
+    <p>Ignore test failures if test passes at least once.  This is useful when tests are being retried on failure.
+        If the test passes after failures, the build will still be marked as stable.</p>
+</div>

--- a/src/test/java/hudson/plugins/testng/PublisherCtor.java
+++ b/src/test/java/hudson/plugins/testng/PublisherCtor.java
@@ -13,10 +13,11 @@ public class PublisherCtor {
     private boolean showFailedBuilds = false;
     private boolean unstableOnSkippedTests = false;
     private boolean failureOnFailedTestConfig = false;
+    private boolean ignoreTestFailureIfTestPassesOnce = false;
 
     public Publisher getNewPublisher() {
         return new Publisher(reportFilenamePattern, escapeTestDescp, escapeExceptionMsg, showFailedBuilds,
-                unstableOnSkippedTests, failureOnFailedTestConfig);
+                unstableOnSkippedTests, failureOnFailedTestConfig, ignoreTestFailureIfTestPassesOnce);
     }
 
     public PublisherCtor setReportFilenamePattern(String reportFilenamePattern) {
@@ -46,6 +47,11 @@ public class PublisherCtor {
 
     public PublisherCtor setFailureOnFailedTestConfig(boolean failureOnFailedTestConfig) {
         this.failureOnFailedTestConfig = failureOnFailedTestConfig;
+        return this;
+    }
+
+    public PublisherCtor setIgnoreTestFailureIfTestPassesOnceConfig(boolean ignoreTestFailureIfTestPassesOnce) {
+        this.ignoreTestFailureIfTestPassesOnce = ignoreTestFailureIfTestPassesOnce;
         return this;
     }
 }

--- a/src/test/java/hudson/plugins/testng/PublisherTest.java
+++ b/src/test/java/hudson/plugins/testng/PublisherTest.java
@@ -91,7 +91,7 @@ public class PublisherTest extends HudsonTestCase {
     @Test
     public void testRoundTrip() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
-        Publisher before = new Publisher("", false, false, true, true, true);
+        Publisher before = new Publisher("", false, false, true, true, true, true);
         p.getPublishersList().add(before);
 
         submit(createWebClient().getPage(p,"configure").getFormByName("config"));


### PR DESCRIPTION
TestNG allows you to use a retry listener.  That causes the test output to have failed tests in it, but those may not be that significant if the test eventually passes.  

In that case, most people will want to see the test output for the failed tests in their jenkins task results but keep the task in the stable state if the specific test passed at least once.  The current plugin will always mark it as unstable if there are any failed tests.  

This pull request adds an optional flag that defaults to false, called "ignoreTestFailureIfTestPassesOnce ".  If this flag is set to "true" then the testng jenkins plugin will ignore the test failures for the retried test if it eventually passes.  If it is "false"  it will keep the current behavior and be backward compatible.