### PR TITLE
Fixing compilation issue caused if the user does not configure repositories and plugin repo in maven settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,5 +67,17 @@
         <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>


### PR DESCRIPTION
The code current maven pom fails to download the dependency and jenkins plugin jar by default. Users have to manually configure the repository and plugin repository in settings.xml to download the dependent jars. This pull request fixes it.