### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/src/main/java/hudson/plugins/testng/results/MethodResultException.java
+++ b/src/main/java/hudson/plugins/testng/results/MethodResultException.java
@@ -79,7 +79,7 @@ public class MethodResultException implements Serializable {
    }
 
    public String toString() {
-      StringBuffer str = new StringBuffer();
+      StringBuilder str = new StringBuilder();
       str.append(exceptionName).append(": ");
       if (message != null) {
          str.append(message);

--- a/src/main/java/hudson/plugins/testng/results/PackageResult.java
+++ b/src/main/java/hudson/plugins/testng/results/PackageResult.java
@@ -140,7 +140,7 @@ public class PackageResult extends BaseResult {
      * @return table row representation
      */
     private String getMethodExecutionTableContent(List<MethodResult> mrList) {
-        StringBuffer sb = new StringBuffer(mrList.size() * 100);
+        StringBuilder sb = new StringBuilder(mrList.size() * 100);
 
         for (MethodResult mr : mrList) {
             sb.append("<tr><td align=\"left\">");

--- a/src/main/java/hudson/plugins/testng/util/TestResultHistoryUtil.java
+++ b/src/main/java/hudson/plugins/testng/util/TestResultHistoryUtil.java
@@ -95,7 +95,7 @@ public class TestResultHistoryUtil {
       </OL>
    */
    private static String printTestsUrls(AbstractBuild<?,?> owner, List<MethodResult> methodResults) {
-      StringBuffer htmlStr = new StringBuffer();
+       StringBuilder htmlStr = new StringBuilder();
       htmlStr.append("<OL>");
       if (methodResults != null && methodResults.size() > 0) {
          for (MethodResult methodResult : methodResults) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed