### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/hudson/plugins/testng/util/FormatUtil.java
+++ b/src/main/java/hudson/plugins/testng/util/FormatUtil.java
@@ -13,6 +13,8 @@ public class FormatUtil {
     public static final String MORE_THAN_24HRS = "> 24hrs";
     private static final long HOUR_IN_SEC = 60 * 60;
     private static final long MIN_IN_SEC = 60;
+    
+    private FormatUtil() {}
 
    /**
     * Formats the time into a human readable format

--- a/src/main/java/hudson/plugins/testng/util/TestResultHistoryUtil.java
+++ b/src/main/java/hudson/plugins/testng/util/TestResultHistoryUtil.java
@@ -14,6 +14,8 @@ import hudson.plugins.testng.results.TestNGResult;
  * @author nullin
  */
 public class TestResultHistoryUtil {
+    
+    private TestResultHistoryUtil() {}
 
    /**
     * Gets the latest build before this one and returns it's test result.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed