### PR TITLE
Code quality fix - Class variable fields should not have public accessibility.

### DIFF
--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -45,14 +45,14 @@ public class Publisher extends Recorder {
    @Deprecated
    public transient boolean unstableOnSkippedTests;
    //number of skips that will trigger "Unstable"
-   public Integer unstableSkips;
+   private Integer unstableSkips;
    //number of fails that will trigger "Unstable"
-   public Integer unstableFails;
+   private Integer unstableFails;
    //number of skips that will trigger "Failed"
-   public Integer failedSkips;
+   private Integer failedSkips;
    //number of fails that will trigger "Failed"
-   public Integer failedFails;
-   public Integer thresholdMode;
+   private Integer failedFails;
+   private Integer thresholdMode;
 
 
    @Extension


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck

Please let me know if you have any questions.

Faisal Hameed