### PR TITLE
Partially roll back commit for using LastBuildAction.

### DIFF
--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import hudson.EnvVars;
@@ -13,6 +15,7 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -163,6 +166,13 @@ public class Publisher extends Recorder implements SimpleBuildStep {
       return DESCRIPTOR;
    }
 
+   @Override
+   public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) { // TODO replace with LastBuildAction
+      Collection<Action> actions = new ArrayList<Action>();
+      actions.add(new TestNGProjectAction(project, escapeTestDescp, escapeExceptionMsg, showFailedBuilds));
+      return actions;
+   }
+
    /**
     * {@inheritDoc}
     */
@@ -222,7 +232,7 @@ public class Publisher extends Recorder implements SimpleBuildStep {
 
       if (results.getTestList().size() > 0) {
          //create an individual report for all of the results and add it to the build
-         build.addAction(new TestNGTestResultBuildAction(results, escapeTestDescp, escapeExceptionMsg, showFailedBuilds));
+         build.addAction(new TestNGTestResultBuildAction(results));
          if (failureOnFailedTestConfig && results.getFailedConfigCount() > 0) {
             logger.println("Failed configuration methods found. Marking build as FAILURE.");
             build.setResult(Result.FAILURE);

--- a/src/main/java/hudson/plugins/testng/TestNGProjectAction.java
+++ b/src/main/java/hudson/plugins/testng/TestNGProjectAction.java
@@ -5,6 +5,7 @@ import hudson.model.AbstractBuild;
 import java.io.IOException;
 import java.util.Calendar;
 
+import hudson.model.Action;
 import hudson.model.Job;
 import hudson.model.ProminentProjectAction;
 import hudson.model.Result;
@@ -13,6 +14,7 @@ import hudson.plugins.testng.util.GraphHelper;
 import hudson.tasks.test.TestResultProjectAction;
 import hudson.util.ChartUtil;
 import hudson.util.DataSetBuilder;
+
 import java.util.SortedMap;
 import jenkins.model.lazy.LazyBuildMixIn;
 import jenkins.model.lazy.LazyBuildMixIn.LazyLoadingJob;
@@ -50,6 +52,11 @@ public class TestNGProjectAction extends TestResultProjectAction implements Prom
    }
 
    public boolean getEscapeExceptionMsg()
+   {
+      return escapeExceptionMsg;
+   }
+
+   public boolean getShowFailedBuilds()
    {
       return escapeExceptionMsg;
    }

--- a/src/main/java/hudson/plugins/testng/TestNGTestResultBuildAction.java
+++ b/src/main/java/hudson/plugins/testng/TestNGTestResultBuildAction.java
@@ -11,7 +11,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import hudson.FilePath;
-import hudson.model.Action;
 import hudson.model.Api;
 import hudson.model.Run;
 import hudson.plugins.testng.parser.ResultsParser;
@@ -19,9 +18,6 @@ import hudson.plugins.testng.results.MethodResult;
 import hudson.plugins.testng.results.TestNGResult;
 import hudson.tasks.junit.CaseResult;
 import hudson.tasks.test.AbstractTestResultAction;
-import java.util.Collection;
-import java.util.Collections;
-import jenkins.tasks.SimpleBuildStep;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -31,7 +27,7 @@ import org.kohsuke.stapler.StaplerResponse;
  * @author nullin
  * @since v1.0
  */
-public class TestNGTestResultBuildAction extends AbstractTestResultAction implements Serializable, SimpleBuildStep.LastBuildAction {
+public class TestNGTestResultBuildAction extends AbstractTestResultAction implements Serializable {
 
     private static final Logger LOGGER = Logger.getLogger(TestNGTestResultBuildAction.class.getName());
 
@@ -52,20 +48,14 @@ public class TestNGTestResultBuildAction extends AbstractTestResultAction implem
     protected Integer passCount; // null if uncomputed
     protected int failCount;
     protected int skipCount;
-    private final boolean escapeTestDescp;
-    private final boolean escapeExceptionMsg;
-    private final boolean showFailedBuilds;
 
-    public TestNGTestResultBuildAction(TestNGResult testngResults, boolean escapeTestDescp, boolean escapeExceptionMsg, boolean showFailedBuilds) {
+    public TestNGTestResultBuildAction(TestNGResult testngResults) {
         if (testngResults != null) {
             this.testngResultRef = new WeakReference<TestNGResult>(testngResults);
 
             //initialize the cached values when TestNGBuildAction is instantiated
             count(testngResults);
         }
-        this.escapeTestDescp = escapeTestDescp;
-        this.escapeExceptionMsg = escapeExceptionMsg;
-        this.showFailedBuilds = showFailedBuilds;
     }
 
     private void count(TestNGResult testngResults) {
@@ -219,11 +209,6 @@ public class TestNGTestResultBuildAction extends AbstractTestResultAction implem
         }
 
         return results;
-    }
-
-    @Override
-    public Collection<? extends Action> getProjectActions() {
-        return Collections.singleton(new TestNGProjectAction(run.getParent(), escapeTestDescp, escapeExceptionMsg, showFailedBuilds));
     }
 
 }


### PR DESCRIPTION
This is a fix for JENKINS-26971
Also added a getter for showFailedBuilds so that tests will pass.

This is a partial rollback for [this](https://github.com/jenkinsci/testng-plugin-plugin/commit/924457576719bb67b3391cedd13bd4d66060c4b8#diff-b1996c7392724f8e7f9b91c7ae3c4974) commit, which should never have been merged as it causes tests (`mvn clean verify`) to fail.