### PR TITLE
[JENKINS-51341] Display suite name at main page and at method result page

### DIFF
--- a/src/main/java/hudson/plugins/testng/util/TestResultHistoryUtil.java
+++ b/src/main/java/hudson/plugins/testng/util/TestResultHistoryUtil.java
@@ -98,9 +98,24 @@ public class TestResultHistoryUtil {
    */
    private static String printTestsUrls(List<MethodResult> methodResults) {
       StringBuilder htmlStr = new StringBuilder();
-      htmlStr.append("<OL>");
+      htmlStr.append("<UL>");
+      boolean firstGroup = true;
+      String testName = "";
+      String suiteName = "";
+      int testIndex = 1;
       if (methodResults != null && methodResults.size() > 0) {
          for (MethodResult methodResult : methodResults) {
+            if (!testName.equals(methodResult.getParentTestName())
+                    || !suiteName.equals(methodResult.getParentSuiteName())) {
+               if (!firstGroup) {
+                  htmlStr.append("</OL></LI>");
+               }
+               firstGroup = false;
+               testName = methodResult.getParentTestName();
+               suiteName = methodResult.getParentSuiteName();
+               htmlStr.append("<LI style=\"list-style-type:none\"><b>").append(testName).append(" / ").append(suiteName).append("</b>");
+               htmlStr.append("<OL start=\"").append(testIndex).append("\">");
+            }
             htmlStr.append("<LI>");
             if (methodResult.getParent() instanceof ClassResult) {
                htmlStr.append("<a href=\"").append(methodResult.getUpUrl());
@@ -111,10 +126,14 @@ public class TestResultHistoryUtil {
                htmlStr.append(methodResult.getName());
             }
             htmlStr.append("</LI>");
+            testIndex++;
          }
 
       }
-      htmlStr.append("</OL>");
+      if (!firstGroup) {
+         htmlStr.append("</OL></LI>");
+      }
+      htmlStr.append("</UL>");
       return htmlStr.substring(0);
    }
 

--- a/src/main/resources/hudson/plugins/testng/results/MethodResult/reportDetail.groovy
+++ b/src/main/resources/hudson/plugins/testng/results/MethodResult/reportDetail.groovy
@@ -37,6 +37,18 @@ div(id: "report") {
         }
     }
 
+    if (my.parentTestName) {
+        div(id: "parent-test-name") {
+            text("Test Name: ${my.parentTestName}")
+        }
+    }
+
+    if (my.parentSuiteName) {
+        div(id: "parent-suite-name") {
+            text("Suite Name: ${my.parentSuiteName}")
+        }
+    }
+
     if (my.groups) {
         div(id: "groups") {
             p("Group(s): ${StringUtils.join(my.groups, ", ")}")
@@ -98,7 +110,7 @@ div(id: "report") {
         if (my.exception.stackTrace) {
             b("Stacktrace:")
             p(id:"exp-st") {
-                raw("${FormatUtil.formatStackTraceForHTML(my.exception.stackTrace)}")
+                pre(my.exception.stackTrace)
             }
         }
     }


### PR DESCRIPTION
The test failures at the main page are shown in the order of execution,
all the failures are numbered sequentially (like it was before)

New: suite name and test name is printed as well

<img width="684" alt="2018-06-04 16 31 58" src="https://user-images.githubusercontent.com/213894/40920329-dcafcd08-6814-11e8-9e6d-95de8035a870.png">
