### PR TITLE
install gh during Gitpod startup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,6 +12,9 @@ tasks:
       sdk update
       sdk install maven 3.8.3
       sdk use maven 3.8.3
+  - name: install gh
+    before: |
+      brew install gh
 vscode:
   extensions:
     - bierner.markdown-preview-github-styles


### PR DESCRIPTION
Install gh CLI in order to simplify interactions with GitHub from within Gitpod

Signed-off-by: Darin Pope <darin@planetpope.com>