### PR TITLE
[JENKINS-67098] Render summary graph with GET or POST

### DIFF
--- a/src/main/java/hudson/plugins/testng/TestNGProjectAction.java
+++ b/src/main/java/hudson/plugins/testng/TestNGProjectAction.java
@@ -20,7 +20,6 @@ import org.jfree.chart.JFreeChart;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
-import org.kohsuke.stapler.verb.POST;
 
 /**
  * Action to associate the TestNG reports with the project
@@ -107,7 +106,7 @@ public class TestNGProjectAction extends TestResultProjectAction implements Prom
     * @param rsp -
     * @throws IOException -
     */
-   @POST
+   // @org.kohsuke.stapler.verb.POST // POST blocks graph rendering in groovy web page
    public void doGraph(final StaplerRequest req,
                       StaplerResponse rsp) throws IOException {
       if (newGraphNotNeeded(req, rsp)) {
@@ -144,7 +143,7 @@ public class TestNGProjectAction extends TestResultProjectAction implements Prom
       return req.checkIfModified(t, rsp);
    }
 
-   @POST
+    // @org.kohsuke.stapler.verb.POST // POST blocks rendering in groovy defined web page
    public void doGraphMap(final StaplerRequest req,
            StaplerResponse rsp) throws IOException {
       if (newGraphNotNeeded(req, rsp)) {


### PR DESCRIPTION
# [JENKINS-67098](https://issues.jenkins.io/browse/JENKINS-67098) Render summary graph with GET or POST

Allow GET requests for the graph.  The page performing the request is defined in groovy and I don't know how to configure the groovy page to make the request with POST rather than GET.

Regression in 552.va20eb2369116

## Before the fix

![testng-job-summary-after](https://user-images.githubusercontent.com/156685/141047549-2a77d42a-a9c4-4f47-921c-a1e8d189719c.png)

## After the fix

![testng-job-summary-before](https://user-images.githubusercontent.com/156685/141047560-170ed635-a4f5-4d41-ae62-1d162cfcb981.png)

