### PR TITLE
Require Jenkins 2.303.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.289.x</artifactId>
+                <artifactId>bom-2.303.x</artifactId>
                 <version>1135.va_4eeca_ea_21c1</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -147,7 +147,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/testng-plugin-plugin</gitHubRepo>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.303.3</jenkins.version>
         <java.level>8</java.level>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.failOnError>true</spotbugs.failOnError>


### PR DESCRIPTION
## Require Jenkins 2.303.3

Jenkins version recommended by development pages and new enough to allow ongoing updates to the plugin BOM.
