### PR TITLE
Use Eclipse Temurin, not AdoptOpenJDK in GitHub Action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -47,9 +47,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3.0.0
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 8
     - name: Release
       uses: jenkins-infra/jenkins-maven-cd-action@v1.2.0


### PR DESCRIPTION
## Use Eclipse Temurin, not AdoptOpenJDK for GitHub Action

AdoptOpenJDK is no longer being updated.  See https://github.com/actions/setup-java#usage where it says:

> NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
