### PR TITLE
Add `testNG` symbol for Pipeline syntax clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,37 @@ Results**. This option allows you to configure the following properties:
 
 ### Pipeline in Jenkinsfile
 
+The link:https://www.jenkins.io/redirect/pipeline-snippet-generator[Pipeline Syntax Snippet Generator] guides the user to select TestNG report options.
+Add the `testNG` step to declarative Pipeline in a `post` section.
+
 ```
   post {
     always {
-      step([$class: 'Publisher', reportFilenamePattern: '**/testng-results.xml'])
+      testNG()
     }
   }
+```
+
+Additional options can be included in the testNG declarative Pipeline step like this:
+
+```
+  post {
+    always {
+      testNG(showFailedBuilds: true,
+             unstableFails: 5, unstableSkips: 25,
+             failedFails:  10, failedSkips:   50)
+    }
+  }
+```
+
+The `testNG` Pipeline step can be used in a scripted Pipeline like this:
+
+```
+node {
+  // Add steps that run TestNG tests
+  // Publish TestNG report with the `testNG()` step
+  testNG(reportFilenamePattern: '**/testng-many-results.xml')
+}
 ```
 
 ### Properties

--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -25,6 +25,7 @@ import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.*;
 import org.kohsuke.stapler.verb.POST;
 
@@ -442,6 +443,7 @@ public class Publisher extends Recorder implements SimpleBuildStep {
       return true;
    }
 
+   @Symbol("testNG")
    public static final class DescriptorImpl extends BuildStepDescriptor<hudson.tasks.Publisher> {
 
       /**


### PR DESCRIPTION
## Add `testNG` symbol for Pipeline syntax generator

Allows the Pipeline snippet syntax generator to suggest syntax for TestNG results and makes it easier to read Pipeline definitions.

Pipeline snippet syntax generator does not correctly handle two boolean flags, but it feels better to have most of the syntax generator working rather than hold this change until all of the syntax generator is working.

Includes an automated test that confirms the symbol `testNG()` works for scripted Pipeline.  Tested interactively to confirm tha new syntax is working for declarative Pipeline.  Existing automated test already checked that the old syntax is still working.

See the README for examples.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
