### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ buildPlugin(failFast: false,
             // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
             artifactCachingProxyEnabled: true,
             configurations: [
-                [platform: 'linux',   jdk: '17', jenkins: '2.342'],
-                [platform: 'linux',   jdk: '11'],
+                [platform: 'linux',   jdk: '17', jenkins: '2.376'],
+                [platform: 'linux',   jdk: '11', jenkins: '2.361.3'],
                 [platform: 'windows', jdk: '8'],
             ])

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.319.x</artifactId>
-                <version>1654.vcb_69d035fa_20</version>
+                <artifactId>bom-2.346.x</artifactId>
+                <version>1670.v7f165fc7a_079</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -140,7 +140,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/testng-plugin-plugin</gitHubRepo>
-        <jenkins.version>2.319.3</jenkins.version>
+        <jenkins.version>2.346.3</jenkins.version>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.failOnError>true</spotbugs.failOnError>
         <!-- Not yet ready for Low threshold, too many warnings to resolve -->


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

Bill of materials for Jenkins 2.139.x is no longer being updated.  Use a newer version.

- Require Jenkins 2.346.3 or newer
- Adjust tested versions for new Jenkins min version

Updates the Jenkinsfile based on the version requirements.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
