### PR TITLE
[JENKINS-71331] Show plugin docs on plugins site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,9 @@
   <version>${changelist}</version>
   <packaging>hpi</packaging>
   <name>TestNG Results Plugin</name>
-  <url>https://github.com/${gitHubRepo}</url>
+  <!-- url using more typical form does not work as expected -->
+  <!-- declare exact path to documentation -->
+  <url>https://github.com/jenkinsci/testng-plugin-plugin/blob/master/README.md</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
## [JENKINS-71331] Show plugin docs on plugins site

Recent changes to pom.xml may be the root cause of the missing documentation on https://plugins.jenkins.io/testng-plugin/

https://plugins.jenkins.io/testng-plugin/ shows a link to the plugin documentation page instead of displaying the plugin documentation. Other plugins correctly display their documentation on the plugins page. The TestNG plugin displayed its documentation correctly in the past, but does not do so now.

I suspect that the problem is caused by my changes to make the pom.xml file more consistent among the plugins that I maintain. It may be related to the rather odd naming of the GitHub repository as testng-plugin-plugin.

### Testing done

No testing performed.  I want to release the most recent changes and this is a good excuse to deliver a new release.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
