### PR TITLE
Bundle XML pull parser for forward compatibility with jenkinsci/jenkins#8503

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>io.github.x-stream</groupId>
+      <artifactId>mxparser</artifactId>
+      <version>1.2.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
     </dependency>


### PR DESCRIPTION
Without dropping support for existing cores (where this library will simply be ignored in favor of core's copy), add forward compatibility for https://github.com/jenkinsci/jenkins/pull/8503 by bundling XML Pull Parser 3rd Edition within this plugin's HPI file rather than relying on core's copy, thereby enabling us to remove this library from core.

### Testing done

I ran a build with the TestNG plugin and https://github.com/jenkinsci/jenkins/pull/8503, confirming that the following exception was now thrown (as expected):

```
13:32:33 java.lang.NoClassDefFoundError: org/xmlpull/v1/XmlPullParserException
13:32:33 	at hudson.plugins.testng.TestNGTestResultBuildAction.loadResults(TestNGTestResultBuildAction.java:128)
13:32:33 	at hudson.plugins.testng.Publisher.perform(Publisher.java:252)
13:32:33 	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:123)
13:32:33 	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:80)
13:32:33 	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
13:32:33 	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:818)
13:32:33 	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:767)
13:32:33 	at hudson.model.Build$BuildExecution.post2(Build.java:179)
13:32:33 	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:711)
13:32:33 	at hudson.model.Run.execute(Run.java:1920)
13:32:33 	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:44)
13:32:33 	at hudson.model.ResourceController.execute(ResourceController.java:101)
13:32:33 	at hudson.model.Executor.run(Executor.java:442)
13:32:33 Caused by: java.lang.ClassNotFoundException: org.xmlpull.v1.XmlPullParserException
13:32:33 	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
13:32:33 	at jenkins.util.URLClassLoader2.findClass(URLClassLoader2.java:35)
13:32:33 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:593)
13:32:33 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
13:32:33 	... 13 more
```

I also verified that this exception went away after the changes in this PR and that XML Pull Parser 3rd edition was bundled in this plugin's HPI:

```
[INFO] Assembling webapp testng-plugin in /home/basil/src/jenkinsci/testng-plugin-plugin/target/testng-plugin
[INFO] Bundling direct dependency mxparser-1.2.2.jar
[WARNING] Bundling transitive dependency xmlpull-1.1.3.1.jar (via mxparser)
```