### PR TITLE
Fix link to Syntax Snippet Generator in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Results**. This option allows you to configure the following properties:
 
 ### Pipeline in Jenkinsfile
 
-The link: [Pipeline Syntax Snippet Generator](https://www.jenkins.io/redirect/pipeline-snippet-generator) guides the user to select TestNG report options.
+The [Pipeline Syntax Snippet Generator](https://www.jenkins.io/redirect/pipeline-snippet-generator) guides the user to select TestNG report options.
 Add the `testNG` step to declarative Pipeline in a `post` section.
 
 ```

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Results**. This option allows you to configure the following properties:
 
 ### Pipeline in Jenkinsfile
 
-The link:https://www.jenkins.io/redirect/pipeline-snippet-generator[Pipeline Syntax Snippet Generator] guides the user to select TestNG report options.
+The link: [Pipeline Syntax Snippet Generator](https://www.jenkins.io/redirect/pipeline-snippet-generator) guides the user to select TestNG report options.
 Add the `testNG` step to declarative Pipeline in a `post` section.
 
 ```


### PR DESCRIPTION
The link to the Snippet Generator documentation is not correctly displayed / usable

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
```