### PR TITLE
Require Jenkins 2.479.1 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
 
@@ -34,8 +34,9 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <!-- Not yet ready for Low threshold, too many warnings to resolve -->
     <spotbugs.threshold>Medium</spotbugs.threshold>
@@ -47,7 +48,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>4136.vca_c3202a_7fd1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -216,10 +216,10 @@ public class Publisher extends Recorder implements SimpleBuildStep {
         }
 
         String pathsPattern;
-        if (build instanceof AbstractBuild) {
+        if (build instanceof AbstractBuild<?, ?> abstractBuild) {
             // replace any variables in the user specified pattern
             EnvVars env = build.getEnvironment(listener);
-            env.overrideAll(((AbstractBuild) build).getBuildVariables());
+            env.overrideAll(abstractBuild.getBuildVariables());
             pathsPattern = env.expand(reportFilenamePattern);
         } else {
             pathsPattern = reportFilenamePattern;
@@ -268,48 +268,45 @@ public class Publisher extends Recorder implements SimpleBuildStep {
             } else {
                 if (thresholdMode == 1) { // number of tests
                     if (results.getFailCount() > failedFails) {
-                        logger.println(String.format(
-                                "%d tests failed, which exceeded threshold of %d. Marking build as FAILURE",
-                                results.getFailCount(), failedFails));
+                        logger.println("%d tests failed, which exceeded threshold of %d. Marking build as FAILURE"
+                                .formatted(results.getFailCount(), failedFails));
                         build.setResult(Result.FAILURE);
                     } else if (results.getSkipCount() > failedSkips) {
-                        logger.println(String.format(
-                                "%d tests were skipped, which exceeded threshold of %d. Marking build as FAILURE",
-                                results.getSkipCount(), failedSkips));
+                        logger.println("%d tests were skipped, which exceeded threshold of %d. Marking build as FAILURE"
+                                .formatted(results.getSkipCount(), failedSkips));
                         build.setResult(Result.FAILURE);
                     } else if (results.getFailCount() > unstableFails) {
-                        logger.println(String.format(
-                                "%d tests failed, which exceeded threshold of %d. Marking build as UNSTABLE",
-                                results.getFailCount(), unstableFails));
+                        logger.println("%d tests failed, which exceeded threshold of %d. Marking build as UNSTABLE"
+                                .formatted(results.getFailCount(), unstableFails));
                         build.setResult(Result.UNSTABLE);
                     } else if (results.getSkipCount() > unstableSkips) {
-                        logger.println(String.format(
-                                "%d tests were skipped, which exceeded threshold of %d. Marking build as UNSTABLE",
-                                results.getSkipCount(), unstableSkips));
+                        logger.println(
+                                "%d tests were skipped, which exceeded threshold of %d. Marking build as UNSTABLE"
+                                        .formatted(results.getSkipCount(), unstableSkips));
                         build.setResult(Result.UNSTABLE);
                     }
                 } else if (thresholdMode == 2) { // percentage of tests
                     float failedPercent = 100 * results.getFailCount() / (float) results.getTotalCount();
                     float skipPercent = 100 * results.getSkipCount() / (float) results.getTotalCount();
                     if (failedPercent > failedFails) {
-                        logger.println(String.format(
-                                "%f%% of tests failed, which exceeded threshold of %d%%. Marking build as FAILURE",
-                                failedPercent, failedFails));
+                        logger.println(
+                                "%f%% of tests failed, which exceeded threshold of %d%%. Marking build as FAILURE"
+                                        .formatted(failedPercent, failedFails));
                         build.setResult(Result.FAILURE);
                     } else if (skipPercent > failedSkips) {
-                        logger.println(String.format(
-                                "%f%% of tests were skipped, which exceeded threshold of %d%%. Marking build as FAILURE",
-                                skipPercent, failedSkips));
+                        logger.println(
+                                "%f%% of tests were skipped, which exceeded threshold of %d%%. Marking build as FAILURE"
+                                        .formatted(skipPercent, failedSkips));
                         build.setResult(Result.FAILURE);
                     } else if (failedPercent > unstableFails) {
-                        logger.println(String.format(
-                                "%f%% of tests failed, which exceeded threshold of %d%%. Marking build as UNSTABLE",
-                                failedPercent, unstableFails));
+                        logger.println(
+                                "%f%% of tests failed, which exceeded threshold of %d%%. Marking build as UNSTABLE"
+                                        .formatted(failedPercent, unstableFails));
                         build.setResult(Result.UNSTABLE);
                     } else if (skipPercent > unstableSkips) {
-                        logger.println(String.format(
-                                "%f%% of tests were skipped, which exceeded threshold of %d%%. Marking build as UNSTABLE",
-                                skipPercent, unstableSkips));
+                        logger.println(
+                                "%f%% of tests were skipped, which exceeded threshold of %d%%. Marking build as UNSTABLE"
+                                        .formatted(skipPercent, unstableSkips));
                         build.setResult(Result.UNSTABLE);
                     }
                 } else {

--- a/src/main/java/hudson/plugins/testng/Publisher.java
+++ b/src/main/java/hudson/plugins/testng/Publisher.java
@@ -457,7 +457,7 @@ public class Publisher extends Recorder implements SimpleBuildStep {
         }
 
         @Override
-        public hudson.tasks.Publisher newInstance(@NonNull StaplerRequest req, JSONObject formData)
+        public hudson.tasks.Publisher newInstance(@NonNull StaplerRequest2 req, JSONObject formData)
                 throws FormException {
             return req.bindJSON(Publisher.class, formData);
         }

--- a/src/main/java/hudson/plugins/testng/TestNGProjectAction.java
+++ b/src/main/java/hudson/plugins/testng/TestNGProjectAction.java
@@ -17,8 +17,8 @@ import jenkins.model.lazy.LazyBuildMixIn;
 import jenkins.model.lazy.LazyBuildMixIn.LazyLoadingJob;
 import org.jfree.chart.JFreeChart;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  * Action to associate the TestNG reports with the project
@@ -110,7 +110,7 @@ public class TestNGProjectAction extends TestResultProjectAction implements Prom
      * @throws IOException -
      */
     // @org.kohsuke.stapler.verb.POST // POST blocks graph rendering in groovy web page
-    public void doGraph(final StaplerRequest req, StaplerResponse rsp) throws IOException {
+    public void doGraph(final StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
         if (newGraphNotNeeded(req, rsp)) {
             return;
         }
@@ -139,13 +139,13 @@ public class TestNGProjectAction extends TestResultProjectAction implements Prom
      * @param rsp response
      * @return true, if new image does NOT need to be generated, false otherwise
      */
-    private boolean newGraphNotNeeded(final StaplerRequest req, StaplerResponse rsp) {
+    private boolean newGraphNotNeeded(final StaplerRequest2 req, StaplerResponse2 rsp) {
         Calendar t = getProject().getLastCompletedBuild().getTimestamp();
         return req.checkIfModified(t, rsp);
     }
 
     // @org.kohsuke.stapler.verb.POST // POST blocks rendering in groovy defined web page
-    public void doGraphMap(final StaplerRequest req, StaplerResponse rsp) throws IOException {
+    public void doGraphMap(final StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
         if (newGraphNotNeeded(req, rsp)) {
             return;
         }

--- a/src/main/java/hudson/plugins/testng/TestNGTestResultBuildAction.java
+++ b/src/main/java/hudson/plugins/testng/TestNGTestResultBuildAction.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.tasks.SimpleBuildStep;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  * TestNG build action that exposes the results per build
@@ -167,7 +167,7 @@ public class TestNGTestResultBuildAction extends AbstractTestResultAction
         return PluginImpl.URL;
     }
 
-    public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
         return getResult().getDynamic(token, req, rsp);
     }
 

--- a/src/main/java/hudson/plugins/testng/TestNGTestResultBuildAction.java
+++ b/src/main/java/hudson/plugins/testng/TestNGTestResultBuildAction.java
@@ -11,6 +11,7 @@ import hudson.tasks.junit.CaseResult;
 import hudson.tasks.test.AbstractTestResultAction;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
@@ -36,6 +37,7 @@ public class TestNGTestResultBuildAction extends AbstractTestResultAction
     private static final Logger LOGGER = Logger.getLogger(TestNGTestResultBuildAction.class.getName());
 
     /** Unique identifier for this class. */
+    @Serial
     private static final long serialVersionUID = 31415926L;
 
     /**

--- a/src/main/java/hudson/plugins/testng/results/BaseResult.java
+++ b/src/main/java/hudson/plugins/testng/results/BaseResult.java
@@ -8,8 +8,8 @@ import hudson.tasks.test.TabulatedResult;
 import hudson.tasks.test.TestResult;
 import java.io.Serializable;
 import jenkins.model.Jenkins;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -72,7 +72,7 @@ public abstract class BaseResult extends TabulatedResult implements ModelObject,
     }
 
     @Override
-    public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
         for (TestResult result : this.getChildren()) {
             if (token.equals(result.getName())) {
                 return result;

--- a/src/main/java/hudson/plugins/testng/results/ClassResult.java
+++ b/src/main/java/hudson/plugins/testng/results/ClassResult.java
@@ -6,8 +6,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 
 /** Handle results related to a single test class */
@@ -185,7 +185,7 @@ public class ClassResult extends BaseResult {
        applicable)
     */
     @Override
-    public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
         if (this.testMethodList != null) {
             for (MethodResult methodResult : this.testMethodList) {
                 // append the uuid as well

--- a/src/main/java/hudson/plugins/testng/results/MethodResult.java
+++ b/src/main/java/hudson/plugins/testng/results/MethodResult.java
@@ -10,8 +10,8 @@ import hudson.util.Graph;
 import java.io.IOException;
 import java.util.*;
 import org.jfree.chart.JFreeChart;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.verb.POST;
 
@@ -242,7 +242,7 @@ public class MethodResult extends BaseResult {
      * @throws IOException on IO error
      */
     @POST
-    public void doGraph(final StaplerRequest req, StaplerResponse rsp) throws IOException {
+    public void doGraph(final StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
         // Test result graphs should be visible to any user
         // with READ permission. Declaring a checkPermission
         // would be redundant.
@@ -261,7 +261,7 @@ public class MethodResult extends BaseResult {
      * @throws IOException on IO error
      */
     @POST
-    public void doGraphMap(final StaplerRequest req, StaplerResponse rsp) throws IOException {
+    public void doGraphMap(final StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
         Graph g = getGraph(req, rsp);
         if (g != null) {
             g.doMap(req, rsp);
@@ -275,7 +275,7 @@ public class MethodResult extends BaseResult {
      * @param rsp response
      * @return a graph
      */
-    private hudson.util.Graph getGraph(final StaplerRequest req, StaplerResponse rsp) {
+    private hudson.util.Graph getGraph(final StaplerRequest2 req, StaplerResponse2 rsp) {
         Calendar t = getRun().getParent().getLastCompletedBuild().getTimestamp();
         if (req.checkIfModified(t, rsp)) {
             return null;

--- a/src/main/java/hudson/plugins/testng/results/PackageResult.java
+++ b/src/main/java/hudson/plugins/testng/results/PackageResult.java
@@ -11,8 +11,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 import org.kohsuke.stapler.export.Exported;
 
@@ -274,7 +274,7 @@ public class PackageResult extends BaseResult {
      * @return test result
      */
     @Override
-    public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
         if (token.indexOf('.') == -1) {
             return super.getDynamic(token, req, rsp);
         }

--- a/src/main/java/hudson/plugins/testng/results/TestNGResult.java
+++ b/src/main/java/hudson/plugins/testng/results/TestNGResult.java
@@ -3,6 +3,7 @@ package hudson.plugins.testng.results;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Run;
 import hudson.plugins.testng.PluginImpl;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.*;
 import org.kohsuke.stapler.export.Exported;
@@ -17,7 +18,9 @@ import org.kohsuke.stapler.export.Exported;
 @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "ArrayList is Serializable")
 public class TestNGResult extends BaseResult implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -3491974223665601995L;
+
     private List<TestNGTestResult> testList = new ArrayList<TestNGTestResult>();
     private List<MethodResult> passedTests = new ArrayList<MethodResult>();
     private List<MethodResult> failedTests = new ArrayList<MethodResult>();
@@ -169,12 +172,12 @@ public class TestNGResult extends BaseResult implements Serializable {
 
     @Override
     public String toString() {
-        return String.format(
-                "TestNGResult {"
+        return ("TestNGResult {"
                         + "totalTests=%d, "
                         + "failedTests=%d, skippedTests=%d, failedConfigs=%d, "
-                        + "skippedConfigs=%d}", // name,
-                passCount + failCount + skipCount, failCount, skipCount, failedConfigCount, skippedConfigCount);
+                        + "skippedConfigs=%d}")
+                .formatted( // name,
+                        passCount + failCount + skipCount, failCount, skipCount, failedConfigCount, skippedConfigCount);
     }
 
     /** Updates the calculated fields */

--- a/src/main/java/hudson/plugins/testng/util/FormatUtil.java
+++ b/src/main/java/hudson/plugins/testng/util/FormatUtil.java
@@ -32,7 +32,7 @@ public class FormatUtil {
             byte seconds = (byte) duration;
             duration -= seconds;
             int milliseconds = Math.round(duration * 1000f);
-            return String.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
+            return "%02d:%02d:%02d.%03d".formatted(hours, minutes, seconds, milliseconds);
         } catch (Exception e) {
             e.printStackTrace();
             return "-1";

--- a/src/main/java/hudson/plugins/testng/util/GraphHelper.java
+++ b/src/main/java/hudson/plugins/testng/util/GraphHelper.java
@@ -31,8 +31,8 @@ import org.jfree.data.category.CategoryDataset;
 import org.jfree.ui.RectangleEdge;
 import org.jfree.ui.RectangleInsets;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /** Helper class for trend graph generation */
 @SuppressFBWarnings(
@@ -43,12 +43,12 @@ public class GraphHelper {
     /** Do not instantiate GraphHelper. */
     private GraphHelper() {}
 
-    public static void redirectWhenGraphUnsupported(StaplerResponse rsp, StaplerRequest req) throws IOException {
+    public static void redirectWhenGraphUnsupported(StaplerResponse2 rsp, StaplerRequest2 req) throws IOException {
         // not available. send out error message
         rsp.sendRedirect2(req.getContextPath() + "/images/headless.png");
     }
 
-    public static JFreeChart createChart(final StaplerRequest req, CategoryDataset dataset) {
+    public static JFreeChart createChart(final StaplerRequest2 req, CategoryDataset dataset) {
         final JFreeChart chart = ChartFactory.createStackedAreaChart(
                 null, // chart title
                 null, // unused
@@ -140,7 +140,7 @@ public class GraphHelper {
      * @return the chart
      */
     public static JFreeChart createMethodChart(
-            StaplerRequest req,
+            StaplerRequest2 req,
             final CategoryDataset dataset,
             final Map<NumberOnlyBuildLabel, String> statusMap,
             final String methodUrl) {


### PR DESCRIPTION
## Require Jenkins 2.479.1 or newer

Compile with Java 17 and Jakarta EE 9

Transformation is incomplete because the plugin relies on an API provided by the JUnit plugin and that API is only available for the StaplerRequest / StaplerResponse signature and not for the StaplerRequest2 / StaplerResponse2 signature.

### Testing done

Confirmed that automated tests pass.

Confirmed that the dependent plugin (Splunk) does not call any of the methods that changed their signatures

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
